### PR TITLE
fix: synchronize Conversation working state

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2249,17 +2249,21 @@
       "tests/contract/aiSessions/incrementalJsonlLifecycleReader.test.js",
       "tests/contract/aiSessions/codexConversationAdapter.test.js",
       "tests/contract/aiSessions/conversationCoordinator.test.js",
+      "tests/contract/aiSessions/sessionControllers.test.js",
+      "tests/integration/dashboard/conversationLifecycleRefresh.test.js",
       "tests/integration/dashboard/conversationViewer.test.js",
       "tests/browser/conversationViewer.test.js"
     ],
     "evidence": [
       "src/services/codexSessionService.ts",
       "src/aiSessions/executionMonitor.ts",
+      "src/aiSessions/executionController.ts",
       "src/aiSessions/incrementalJsonlLifecycleReader.ts",
       "src/aiSessions/conversation/codexAdapter.ts",
       "src/aiSessions/conversation/composition.ts",
       "src/aiSessions/conversation/viewer.ts",
       "src/aiSessions/conversation/viewerDocument.ts",
+      "src/dashboard.ts",
       "src/webview/conversationViewerScripts.js",
       "media/conversationViewer.scss"
     ]

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -131,7 +131,7 @@ export interface ConversationCapability {
     freezeSessionMetadata(
         target: ConversationSessionOpenTarget
     ): Promise<boolean>;
-    reconcile(): Promise<void>;
+    reconcile(): Promise<boolean>;
     dispose(): void;
 }
 
@@ -965,9 +965,9 @@ function createAvailableConversationCapability(
             viewer.rebindSession(previous, next),
         freezeSessionMetadata: target =>
             viewer.freezeSessionMetadata(target),
-        async reconcile(): Promise<void> {
+        async reconcile(): Promise<boolean> {
             if (disposed) {
-                return;
+                return false;
             }
             try {
                 if (options.resolveReboundTarget) {
@@ -1007,8 +1007,10 @@ function createAvailableConversationCapability(
                         taskName: displayMetadata.conversationTaskName || '',
                     };
                 });
+                return true;
             } catch (_error) {
                 reportUnavailable(options.onDiagnostic);
+                return false;
             }
         },
         dispose(): void {
@@ -1089,7 +1091,9 @@ function createUnavailableConversationCapability(): ConversationCapability {
         async freezeSessionMetadata(): Promise<boolean> {
             return false;
         },
-        async reconcile(): Promise<void> {},
+        async reconcile(): Promise<boolean> {
+            return false;
+        },
         dispose(): void {
             if (disposed) {
                 return;

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -966,12 +966,18 @@ function createAvailableConversationCapability(
         freezeSessionMetadata: target =>
             viewer.freezeSessionMetadata(target),
         async reconcile(expectedTarget?: ConversationSessionOpenTarget): Promise<boolean> {
-            const currentTarget = viewer.getCurrentTarget();
-            if (disposed || (expectedTarget && (!currentTarget
-                || !hasSameConversationSession(currentTarget, expectedTarget)))) {
+            if (disposed) {
                 return false;
             }
             try {
+                if (expectedTarget) {
+                    const currentTarget = viewer.getCurrentTarget();
+                    if (!currentTarget || !hasSameConversationSession(
+                        currentTarget, expectedTarget
+                    )) {
+                        return false;
+                    }
+                }
                 if (options.resolveReboundTarget) {
                     await viewer.reconcileReboundSession(
                         options.resolveReboundTarget

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -131,7 +131,7 @@ export interface ConversationCapability {
     freezeSessionMetadata(
         target: ConversationSessionOpenTarget
     ): Promise<boolean>;
-    reconcile(): Promise<boolean>;
+    reconcile(expectedTarget?: ConversationSessionOpenTarget): Promise<boolean>;
     dispose(): void;
 }
 
@@ -965,8 +965,10 @@ function createAvailableConversationCapability(
             viewer.rebindSession(previous, next),
         freezeSessionMetadata: target =>
             viewer.freezeSessionMetadata(target),
-        async reconcile(): Promise<boolean> {
-            if (disposed) {
+        async reconcile(expectedTarget?: ConversationSessionOpenTarget): Promise<boolean> {
+            const currentTarget = viewer.getCurrentTarget();
+            if (disposed || (expectedTarget && (!currentTarget
+                || !hasSameConversationSession(currentTarget, expectedTarget)))) {
                 return false;
             }
             try {
@@ -975,7 +977,17 @@ function createAvailableConversationCapability(
                         options.resolveReboundTarget
                     );
                 }
+                const reconciledTarget = viewer.getCurrentTarget();
+                if (expectedTarget && (!reconciledTarget
+                    || !hasSameConversationSession(reconciledTarget, expectedTarget))) {
+                    return false;
+                }
                 await viewer.reconcileAuthority(target => {
+                    if (expectedTarget && !hasSameConversationSession(
+                        target, expectedTarget
+                    )) {
+                        return false;
+                    }
                     const authoritativeTarget = resolveExactTarget(
                         options,
                         target

--- a/src/aiSessions/conversation/composition.ts
+++ b/src/aiSessions/conversation/composition.ts
@@ -983,10 +983,13 @@ function createAvailableConversationCapability(
                         options.resolveReboundTarget
                     );
                 }
-                const reconciledTarget = viewer.getCurrentTarget();
-                if (expectedTarget && (!reconciledTarget
-                    || !hasSameConversationSession(reconciledTarget, expectedTarget))) {
-                    return false;
+                if (expectedTarget) {
+                    const reconciledTarget = viewer.getCurrentTarget();
+                    if (!reconciledTarget || !hasSameConversationSession(
+                        reconciledTarget, expectedTarget
+                    )) {
+                        return false;
+                    }
                 }
                 await viewer.reconcileAuthority(target => {
                     if (expectedTarget && !hasSameConversationSession(

--- a/src/aiSessions/executionController.ts
+++ b/src/aiSessions/executionController.ts
@@ -15,7 +15,25 @@ export interface AiSessionExecutionControllerOptions {
     getActiveSessions: () => AiSessionActiveTerminalRuntime[];
     getSessionKey?: (providerId: AiSessionProviderId, sessionId: string) => string;
     scheduleRefresh: (reason: string) => void;
+    /**
+     * Runs for execution-state edges and newly accepted terminal signals.
+     * Unlike a list-view refresh, Conversation can remain visible while that
+     * view is hidden, so it needs its own lifecycle notification.
+     */
+    onExecutionLifecycleChanged?: (changedKeys: readonly string[]) => void;
     nowMs: () => number;
+}
+
+/**
+ * Conversation only needs to reload when its own provider/session lifecycle
+ * changed; a background session edge must not replace the reader's page.
+ */
+export function shouldRefreshConversationForExecutionChange(
+    changedKeys: readonly string[],
+    providerId: AiSessionProviderId,
+    sessionId: string
+): boolean {
+    return changedKeys.includes(getAiSessionKey(providerId, sessionId));
 }
 
 export class AiSessionExecutionController {
@@ -43,6 +61,13 @@ export class AiSessionExecutionController {
         })));
         if (changedKeys.length) {
             this.options.scheduleRefresh('execution');
+        }
+        const conversationRefreshKeys = Array.from(new Set([
+            ...changedKeys,
+            ...this.monitor.getAcceptedTerminalKeys(),
+        ]));
+        if (conversationRefreshKeys.length) {
+            this.options.onExecutionLifecycleChanged?.(conversationRefreshKeys);
         }
     }
 

--- a/src/aiSessions/executionMonitor.ts
+++ b/src/aiSessions/executionMonitor.ts
@@ -26,6 +26,7 @@ interface Entry extends AiSessionExecutionSnapshot {
 
 export default class AiSessionExecutionMonitor {
     private readonly entries = new Map<string, Entry>();
+    private acceptedTerminalKeys: string[] = [];
     private readonly now: () => number;
     private readonly staleRunningTimeoutMs: number;
 
@@ -37,6 +38,7 @@ export default class AiSessionExecutionMonitor {
     evaluate(inputs: AiSessionExecutionInput[]): string[] {
         const seen = new Set<string>();
         const changed = new Set<string>();
+        const acceptedTerminalKeys = new Set<string>();
         for (const input of inputs || []) {
             if (!input?.key) {
                 continue;
@@ -52,6 +54,9 @@ export default class AiSessionExecutionMonitor {
             if (acceptsLifecycleSignal(entry, signal)) {
                 recordAcceptedLifecycleSignal(entry, signal);
                 entry.lastSignalAtMs = this.now();
+                if (signal.executionState === 'stopped') {
+                    acceptedTerminalKeys.add(input.key);
+                }
                 if (entry.state !== signal.executionState) {
                     entry.state = signal.executionState;
                     entry.stateChangedAt = signal.occurredAtMs;
@@ -93,7 +98,14 @@ export default class AiSessionExecutionMonitor {
                 changed.add(key);
             }
         }
+        this.acceptedTerminalKeys = Array.from(acceptedTerminalKeys);
         return Array.from(changed);
+    }
+
+    /** Terminal signals carry new Conversation content even when the initial
+     * execution projection was already stopped. */
+    getAcceptedTerminalKeys(): readonly string[] {
+        return this.acceptedTerminalKeys;
     }
 
     getSnapshot(): Record<string, AiSessionExecutionSnapshot> {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -392,6 +392,13 @@ export async function refreshViewedConversationForExecutionLifecycle(
     } catch (_error) {
         // Refresh is still useful when the best-effort authority pass fails.
     }
+    const currentTarget = viewer.getCurrentTarget();
+    if (!currentTarget
+        || currentTarget.projectId !== viewedTarget.projectId
+        || currentTarget.provider !== viewedTarget.provider
+        || currentTarget.sessionId !== viewedTarget.sessionId) {
+        return false;
+    }
     void viewer.refresh();
     return true;
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -372,15 +372,25 @@ let activeOpenWorkspaceBridgeClient: OpenWorkspaceBridgeClient | null = null;
  * can be hidden while a Conversation panel remains open, so this path must
  * not depend on a list-view refresh reaching its after-refresh hook.
  */
-export function refreshViewedConversationForExecutionLifecycle(
+export async function refreshViewedConversationForExecutionLifecycle(
     viewer: Pick<ConversationCapability['viewer'], 'getCurrentTarget' | 'refresh'> | undefined,
-    changedKeys: readonly string[]
-): boolean {
+    changedKeys: readonly string[],
+    reconcileConversation?: () => void | Promise<void>
+): Promise<boolean> {
     const viewedTarget = viewer?.getCurrentTarget();
     if (!viewedTarget || !shouldRefreshConversationForExecutionChange(
         changedKeys, viewedTarget.provider, viewedTarget.sessionId
     )) {
         return false;
+    }
+    // A restored Conversation has not necessarily passed through the normal
+    // open flow that seeds its coordinator with the latest execution state.
+    // Reconcile first so the ensuing refresh projects a running latest turn
+    // as inProgress even when its list view is hidden.
+    try {
+        await reconcileConversation?.();
+    } catch (_error) {
+        // Refresh is still useful when the best-effort authority pass fails.
     }
     void viewer.refresh();
     return true;
@@ -1531,8 +1541,10 @@ async function initializeDashboard(
             }
         },
         onExecutionLifecycleChanged: changedKeys => {
-            refreshViewedConversationForExecutionLifecycle(
-                conversationCapability?.viewer, changedKeys
+            void refreshViewedConversationForExecutionLifecycle(
+                conversationCapability?.viewer,
+                changedKeys,
+                () => conversationCapability?.reconcile()
             );
         },
         nowMs: () => Date.now(),

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -187,7 +187,10 @@ import {
     submitConversationPrompt,
 } from './aiSessions/conversation/submission';
 import { AiSessionDashboardController } from './aiSessions/dashboardController';
-import { AiSessionExecutionController } from './aiSessions/executionController';
+import {
+    AiSessionExecutionController,
+    shouldRefreshConversationForExecutionChange,
+} from './aiSessions/executionController';
 import {
     AiSessionAttentionController,
 } from './aiSessions/attentionController';
@@ -363,6 +366,25 @@ const DASHBOARD_BOOTSTRAP_PHASE_ORDER = [
 const DASHBOARD_MODULE_LOADED_AT_MS = performance.now();
 let activeAiSessionAttentionBridgeClient: AttentionBridgeClient | null = null;
 let activeOpenWorkspaceBridgeClient: OpenWorkspaceBridgeClient | null = null;
+
+/**
+ * Runs the Conversation half of an execution lifecycle update. The list view
+ * can be hidden while a Conversation panel remains open, so this path must
+ * not depend on a list-view refresh reaching its after-refresh hook.
+ */
+export function refreshViewedConversationForExecutionLifecycle(
+    viewer: Pick<ConversationCapability['viewer'], 'getCurrentTarget' | 'refresh'> | undefined,
+    changedKeys: readonly string[]
+): boolean {
+    const viewedTarget = viewer?.getCurrentTarget();
+    if (!viewedTarget || !shouldRefreshConversationForExecutionChange(
+        changedKeys, viewedTarget.provider, viewedTarget.sessionId
+    )) {
+        return false;
+    }
+    void viewer.refresh();
+    return true;
+}
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     const monotonicNowMs = () => performance.now();
@@ -1507,6 +1529,11 @@ async function initializeDashboard(
             if (openWorkspaceController) {
                 openWorkspaceController.publish();
             }
+        },
+        onExecutionLifecycleChanged: changedKeys => {
+            refreshViewedConversationForExecutionLifecycle(
+                conversationCapability?.viewer, changedKeys
+            );
         },
         nowMs: () => Date.now(),
     });

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -375,7 +375,7 @@ let activeOpenWorkspaceBridgeClient: OpenWorkspaceBridgeClient | null = null;
 export async function refreshViewedConversationForExecutionLifecycle(
     viewer: Pick<ConversationCapability['viewer'], 'getCurrentTarget' | 'refresh'> | undefined,
     changedKeys: readonly string[],
-    reconcileConversation?: () => void | Promise<void>
+    reconcileConversation?: () => boolean | void | Promise<boolean | void>
 ): Promise<boolean> {
     const viewedTarget = viewer?.getCurrentTarget();
     if (!viewedTarget || !shouldRefreshConversationForExecutionChange(
@@ -387,8 +387,9 @@ export async function refreshViewedConversationForExecutionLifecycle(
     // open flow that seeds its coordinator with the latest execution state.
     // Reconcile first so the ensuing refresh projects a running latest turn
     // as inProgress even when its list view is hidden.
+    let reconciled = false;
     try {
-        await reconcileConversation?.();
+        reconciled = await reconcileConversation?.() === true;
     } catch (_error) {
         // Refresh is still useful when the best-effort authority pass fails.
     }
@@ -399,7 +400,9 @@ export async function refreshViewedConversationForExecutionLifecycle(
         || currentTarget.sessionId !== viewedTarget.sessionId) {
         return false;
     }
-    void viewer.refresh();
+    if (!reconciled) {
+        void viewer.refresh();
+    }
     return true;
 }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -174,6 +174,9 @@ import {
     createConversationCapability,
     resolveConversationCommandLocation,
 } from './aiSessions/conversation/composition';
+import type {
+    ConversationSessionOpenTarget,
+} from './aiSessions/conversation/composition';
 import {
     ConversationPanelRestoreCoordinator,
 } from './aiSessions/conversation/panelRestoreCoordinator';
@@ -375,7 +378,9 @@ let activeOpenWorkspaceBridgeClient: OpenWorkspaceBridgeClient | null = null;
 export async function refreshViewedConversationForExecutionLifecycle(
     viewer: Pick<ConversationCapability['viewer'], 'getCurrentTarget' | 'refresh'> | undefined,
     changedKeys: readonly string[],
-    reconcileConversation?: () => boolean | void | Promise<boolean | void>
+    reconcileConversation?: (
+        target: ConversationSessionOpenTarget
+    ) => boolean | void | Promise<boolean | void>
 ): Promise<boolean> {
     const viewedTarget = viewer?.getCurrentTarget();
     if (!viewedTarget || !shouldRefreshConversationForExecutionChange(
@@ -389,7 +394,7 @@ export async function refreshViewedConversationForExecutionLifecycle(
     // as inProgress even when its list view is hidden.
     let reconciled = false;
     try {
-        reconciled = await reconcileConversation?.() === true;
+        reconciled = await reconcileConversation?.(viewedTarget) === true;
     } catch (_error) {
         // Refresh is still useful when the best-effort authority pass fails.
     }
@@ -1554,7 +1559,7 @@ async function initializeDashboard(
             void refreshViewedConversationForExecutionLifecycle(
                 conversationCapability?.viewer,
                 changedKeys,
-                () => conversationCapability?.reconcile()
+                target => conversationCapability?.reconcile(target)
             );
         },
         nowMs: () => Date.now(),

--- a/tests/contract/aiSessions/sessionControllers.test.js
+++ b/tests/contract/aiSessions/sessionControllers.test.js
@@ -6,7 +6,10 @@ const { AiSessionCreationController } = require('../../../out/aiSessions/creatio
 const { AiSessionResumeController } = require('../../../out/aiSessions/resumeController');
 const { AiSessionTerminalCommandController } = require('../../../out/aiSessions/terminalCommandController');
 const { AiSessionRuntimeTargetChangedError } = require('../../../out/aiSessions/runtimeTypes');
-const { AiSessionExecutionController } = require('../../../out/aiSessions/executionController');
+const {
+    AiSessionExecutionController,
+    shouldRefreshConversationForExecutionChange,
+} = require('../../../out/aiSessions/executionController');
 const {
     AiSessionLifecycleSignalReader,
 } = require('../../../out/aiSessions/lifecycleSignalReader');
@@ -1825,12 +1828,15 @@ test('SESSION-AI-SESSION-TERMINAL-COMMAND-CONTROLLER-001 focuses the workbench o
     ]);
 });
 
-test('SESSION-AI-SESSION-EXECUTION-CONTROLLER-001 schedules one refresh only when lifecycle output changes', () => {
+test('SESSION-AI-SESSION-EXECUTION-CONTROLLER-001 CONVERSATION-WORKING-INDICATOR-001 schedules Dashboard and Conversation refreshes only when lifecycle output changes', () => {
     const refreshes = [];
+    const conversationRefreshes = [];
     let token = 'one';
     const controller = new AiSessionExecutionController({
         getActiveSessions: () => [{ provider: 'codex', sessionId: 's', runStartedAtMs: 1 }],
-        scheduleRefresh: reason => refreshes.push(reason), nowMs: () => 1,
+        scheduleRefresh: reason => refreshes.push(reason),
+        onExecutionLifecycleChanged: keys => conversationRefreshes.push(keys),
+        nowMs: () => 1,
     });
     const signals = () => ({ codex: { s: {
         token, occurredAtMs: token === 'one' ? 2 : 3, executionState: token === 'one' ? 'running' : 'stopped',
@@ -1840,11 +1846,62 @@ test('SESSION-AI-SESSION-EXECUTION-CONTROLLER-001 schedules one refresh only whe
     token = 'two';
     controller.evaluate(signals());
     assert.deepEqual(refreshes, ['execution', 'execution']);
+    assert.deepEqual(conversationRefreshes, [
+        ['codex:s'],
+        ['codex:s'],
+    ], 'every lifecycle edge must refresh the Conversation independently of Dashboard visibility');
     assert.equal(controller.getSnapshot()['codex:s'].state, 'stopped');
 
     assert.deepEqual(controller.getLifecycleRequests(), {
         codex: [{ sessionId: 's', runStartedAtMs: 1 }],
     }, 'the controller publishes its request set for the shared reader to merge');
+});
+
+test('CONVERSATION-WORKING-INDICATOR-001 refreshes only the Conversation whose execution state changed', () => {
+    const changedKeys = ['codex:background-session'];
+    assert.equal(
+        shouldRefreshConversationForExecutionChange(
+            changedKeys, 'codex', 'session-a'
+        ),
+        false,
+        'an unrelated lifecycle edge must not re-render the viewed Conversation'
+    );
+    assert.equal(
+        shouldRefreshConversationForExecutionChange(
+            changedKeys, 'codex', 'background-session'
+        ),
+        true
+    );
+});
+
+test('CONVERSATION-WORKING-INDICATOR-001 refreshes on a first-observed terminal lifecycle signal', () => {
+    const refreshes = [];
+    const conversationRefreshes = [];
+    const controller = new AiSessionExecutionController({
+        getActiveSessions: () => [{
+            provider: 'codex', sessionId: 'session-a', runStartedAtMs: 1,
+        }],
+        scheduleRefresh: reason => refreshes.push(reason),
+        onExecutionLifecycleChanged: keys => conversationRefreshes.push(keys),
+        nowMs: () => 10,
+    });
+    const completed = {
+        codex: {
+            'session-a': {
+                token: 'completed-first-observation',
+                occurredAtMs: 10,
+                executionState: 'stopped',
+            },
+        },
+    };
+
+    controller.evaluate(completed);
+    controller.evaluate(completed);
+
+    assert.deepEqual(refreshes, [],
+        'the stopped execution projection did not change from its initial value');
+    assert.deepEqual(conversationRefreshes, [['codex:session-a']],
+        'the first terminal token still clears a stale Working presentation once');
 });
 
 test('SESSION-AI-SESSION-EXECUTION-MONITOR-001 reads lifecycle signals once for the union of every consumer', () => {

--- a/tests/integration/dashboard/conversationLifecycleRefresh.test.js
+++ b/tests/integration/dashboard/conversationLifecycleRefresh.test.js
@@ -89,6 +89,45 @@ test('CONVERSATION-WORKING-INDICATOR-001 does not refresh a newly selected Conve
         'a lifecycle edge for the previous session must not replace the newly selected reader');
 });
 
+test('CONVERSATION-WORKING-INDICATOR-001 scopes lifecycle reconciliation to the originally viewed Conversation', async () => {
+    const refreshes = [];
+    let currentTarget = {
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+    };
+    let releaseReconcile;
+    const viewer = {
+        getCurrentTarget: () => currentTarget,
+        refresh: async () => {
+            refreshes.push(currentTarget.sessionId);
+        },
+    };
+    const reconcile = expectedTarget => new Promise(resolve => {
+        releaseReconcile = async () => {
+            const targetMatches = !expectedTarget
+                || (expectedTarget.projectId === currentTarget.projectId
+                    && expectedTarget.provider === currentTarget.provider
+                    && expectedTarget.sessionId === currentTarget.sessionId);
+            if (targetMatches) {
+                await viewer.refresh();
+            }
+            resolve(targetMatches);
+        };
+    });
+
+    const refresh = refreshViewedConversationForExecutionLifecycle(
+        viewer, ['codex:session-a'], reconcile
+    );
+    await Promise.resolve();
+    currentTarget = {
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-b',
+    };
+    await releaseReconcile();
+
+    assert.equal(await refresh, false);
+    assert.deepEqual(refreshes, [],
+        'a rebind that finishes after navigation must not refresh the replacement reader');
+});
+
 test('CONVERSATION-WORKING-INDICATOR-001 falls back to one direct refresh when lifecycle reconciliation cannot refresh', async () => {
     const operations = [];
     const viewer = {

--- a/tests/integration/dashboard/conversationLifecycleRefresh.test.js
+++ b/tests/integration/dashboard/conversationLifecycleRefresh.test.js
@@ -36,6 +36,8 @@ test('CONVERSATION-WORKING-INDICATOR-001 synchronizes the viewed Conversation li
     };
     const reconcile = async () => {
         operations.push('reconcile');
+        await viewer.refresh();
+        return true;
     };
 
     assert.equal(
@@ -54,7 +56,7 @@ test('CONVERSATION-WORKING-INDICATOR-001 synchronizes the viewed Conversation li
         true
     );
     assert.deepEqual(operations, ['reconcile', 'refresh'],
-        'the Dashboard lifecycle callback must project running/stopped state before refreshing');
+        'the Dashboard lifecycle callback must project running/stopped state with one refresh');
 });
 
 test('CONVERSATION-WORKING-INDICATOR-001 does not refresh a newly selected Conversation after an older lifecycle reconcile', async () => {
@@ -87,6 +89,31 @@ test('CONVERSATION-WORKING-INDICATOR-001 does not refresh a newly selected Conve
         'a lifecycle edge for the previous session must not replace the newly selected reader');
 });
 
+test('CONVERSATION-WORKING-INDICATOR-001 falls back to one direct refresh when lifecycle reconciliation cannot refresh', async () => {
+    const operations = [];
+    const viewer = {
+        getCurrentTarget: () => ({
+            projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+        }),
+        refresh: async () => {
+            operations.push('refresh');
+        },
+    };
+
+    assert.equal(
+        await refreshViewedConversationForExecutionLifecycle(
+            viewer,
+            ['codex:session-a'],
+            async () => {
+                operations.push('reconcile');
+                return false;
+            }
+        ),
+        true
+    );
+    assert.deepEqual(operations, ['reconcile', 'refresh']);
+});
+
 test('CONVERSATION-WORKING-INDICATOR-001 delivers a completed viewed lifecycle through the Dashboard handler without refreshing for another session', async () => {
     const operations = [];
     const viewer = {
@@ -99,6 +126,8 @@ test('CONVERSATION-WORKING-INDICATOR-001 delivers a completed viewed lifecycle t
     };
     const reconcile = async () => {
         operations.push('reconcile');
+        await viewer.refresh();
+        return true;
     };
     let sessionState = 'running';
     let backgroundState = 'running';

--- a/tests/integration/dashboard/conversationLifecycleRefresh.test.js
+++ b/tests/integration/dashboard/conversationLifecycleRefresh.test.js
@@ -24,47 +24,51 @@ const {
     refreshViewedConversationForExecutionLifecycle,
 } = loadDashboard();
 
-test('CONVERSATION-WORKING-INDICATOR-001 refreshes the viewed Conversation only for its matching lifecycle edge', async () => {
-    const refreshes = [];
+test('CONVERSATION-WORKING-INDICATOR-001 synchronizes the viewed Conversation lifecycle before refreshing its matching edge', async () => {
+    const operations = [];
     const viewer = {
         getCurrentTarget: () => ({
             projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
         }),
         refresh: async () => {
-            refreshes.push('refresh');
+            operations.push('refresh');
         },
+    };
+    const reconcile = async () => {
+        operations.push('reconcile');
     };
 
     assert.equal(
-        refreshViewedConversationForExecutionLifecycle(
-            viewer, ['codex:background-session']
+        await refreshViewedConversationForExecutionLifecycle(
+            viewer, ['codex:background-session'], reconcile
         ),
         false
     );
-    await Promise.resolve();
-    assert.deepEqual(refreshes, [],
+    assert.deepEqual(operations, [],
         'background lifecycle edges must not replace the current reader page');
 
     assert.equal(
-        refreshViewedConversationForExecutionLifecycle(
-            viewer, ['codex:session-a']
+        await refreshViewedConversationForExecutionLifecycle(
+            viewer, ['codex:session-a'], reconcile
         ),
         true
     );
-    await Promise.resolve();
-    assert.deepEqual(refreshes, ['refresh'],
-        'the Dashboard lifecycle callback must refresh the viewed Conversation');
+    assert.deepEqual(operations, ['reconcile', 'refresh'],
+        'the Dashboard lifecycle callback must project running/stopped state before refreshing');
 });
 
 test('CONVERSATION-WORKING-INDICATOR-001 delivers a completed viewed lifecycle through the Dashboard handler without refreshing for another session', async () => {
-    const refreshes = [];
+    const operations = [];
     const viewer = {
         getCurrentTarget: () => ({
             projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
         }),
         refresh: async () => {
-            refreshes.push('refresh');
+            operations.push('refresh');
         },
+    };
+    const reconcile = async () => {
+        operations.push('reconcile');
     };
     let sessionState = 'running';
     let backgroundState = 'running';
@@ -75,7 +79,9 @@ test('CONVERSATION-WORKING-INDICATOR-001 delivers a completed viewed lifecycle t
         ],
         scheduleRefresh: () => undefined,
         onExecutionLifecycleChanged: changedKeys => {
-            refreshViewedConversationForExecutionLifecycle(viewer, changedKeys);
+            void refreshViewedConversationForExecutionLifecycle(
+                viewer, changedKeys, reconcile
+            );
         },
         nowMs: () => 10,
     });
@@ -95,18 +101,20 @@ test('CONVERSATION-WORKING-INDICATOR-001 delivers a completed viewed lifecycle t
     });
 
     controller.evaluate(signals());
-    await Promise.resolve();
-    refreshes.length = 0;
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(operations, ['reconcile', 'refresh'],
+        'a running edge after restoring a Conversation must seed its lifecycle projection');
+    operations.length = 0;
 
     backgroundState = 'stopped';
     controller.evaluate(signals());
-    await Promise.resolve();
-    assert.deepEqual(refreshes, [],
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(operations, [],
         'an unrelated completed session must not refresh the viewed Conversation');
 
     sessionState = 'stopped';
     controller.evaluate(signals());
-    await Promise.resolve();
-    assert.deepEqual(refreshes, ['refresh'],
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(operations, ['reconcile', 'refresh'],
         'the viewed completion must refresh its Conversation even when only lifecycle state changed');
 });

--- a/tests/integration/dashboard/conversationLifecycleRefresh.test.js
+++ b/tests/integration/dashboard/conversationLifecycleRefresh.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+const {
+    AiSessionExecutionController,
+} = require('../../../out/aiSessions/executionController');
+
+function loadDashboard() {
+    const previousLoad = Module._load;
+    try {
+        Module._load = function (request, parent, isMain) {
+            if (request === 'vscode') return {};
+            return previousLoad.call(this, request, parent, isMain);
+        };
+        return require('../../../out/dashboard');
+    } finally {
+        Module._load = previousLoad;
+    }
+}
+
+const {
+    refreshViewedConversationForExecutionLifecycle,
+} = loadDashboard();
+
+test('CONVERSATION-WORKING-INDICATOR-001 refreshes the viewed Conversation only for its matching lifecycle edge', async () => {
+    const refreshes = [];
+    const viewer = {
+        getCurrentTarget: () => ({
+            projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+        }),
+        refresh: async () => {
+            refreshes.push('refresh');
+        },
+    };
+
+    assert.equal(
+        refreshViewedConversationForExecutionLifecycle(
+            viewer, ['codex:background-session']
+        ),
+        false
+    );
+    await Promise.resolve();
+    assert.deepEqual(refreshes, [],
+        'background lifecycle edges must not replace the current reader page');
+
+    assert.equal(
+        refreshViewedConversationForExecutionLifecycle(
+            viewer, ['codex:session-a']
+        ),
+        true
+    );
+    await Promise.resolve();
+    assert.deepEqual(refreshes, ['refresh'],
+        'the Dashboard lifecycle callback must refresh the viewed Conversation');
+});
+
+test('CONVERSATION-WORKING-INDICATOR-001 delivers a completed viewed lifecycle through the Dashboard handler without refreshing for another session', async () => {
+    const refreshes = [];
+    const viewer = {
+        getCurrentTarget: () => ({
+            projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+        }),
+        refresh: async () => {
+            refreshes.push('refresh');
+        },
+    };
+    let sessionState = 'running';
+    let backgroundState = 'running';
+    const controller = new AiSessionExecutionController({
+        getActiveSessions: () => [
+            { provider: 'codex', sessionId: 'session-a', runStartedAtMs: 1 },
+            { provider: 'codex', sessionId: 'background-session', runStartedAtMs: 1 },
+        ],
+        scheduleRefresh: () => undefined,
+        onExecutionLifecycleChanged: changedKeys => {
+            refreshViewedConversationForExecutionLifecycle(viewer, changedKeys);
+        },
+        nowMs: () => 10,
+    });
+    const signals = () => ({
+        codex: {
+            'session-a': {
+                token: `session-a:${sessionState}`,
+                occurredAtMs: sessionState === 'running' ? 1 : 2,
+                executionState: sessionState === 'running' ? 'running' : 'stopped',
+            },
+            'background-session': {
+                token: `background:${backgroundState}`,
+                occurredAtMs: backgroundState === 'running' ? 1 : 2,
+                executionState: backgroundState === 'running' ? 'running' : 'stopped',
+            },
+        },
+    });
+
+    controller.evaluate(signals());
+    await Promise.resolve();
+    refreshes.length = 0;
+
+    backgroundState = 'stopped';
+    controller.evaluate(signals());
+    await Promise.resolve();
+    assert.deepEqual(refreshes, [],
+        'an unrelated completed session must not refresh the viewed Conversation');
+
+    sessionState = 'stopped';
+    controller.evaluate(signals());
+    await Promise.resolve();
+    assert.deepEqual(refreshes, ['refresh'],
+        'the viewed completion must refresh its Conversation even when only lifecycle state changed');
+});

--- a/tests/integration/dashboard/conversationLifecycleRefresh.test.js
+++ b/tests/integration/dashboard/conversationLifecycleRefresh.test.js
@@ -57,6 +57,36 @@ test('CONVERSATION-WORKING-INDICATOR-001 synchronizes the viewed Conversation li
         'the Dashboard lifecycle callback must project running/stopped state before refreshing');
 });
 
+test('CONVERSATION-WORKING-INDICATOR-001 does not refresh a newly selected Conversation after an older lifecycle reconcile', async () => {
+    const refreshes = [];
+    let currentTarget = {
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+    };
+    let releaseReconcile;
+    const viewer = {
+        getCurrentTarget: () => currentTarget,
+        refresh: async () => {
+            refreshes.push(currentTarget.sessionId);
+        },
+    };
+    const reconcile = () => new Promise(resolve => {
+        releaseReconcile = resolve;
+    });
+
+    const refresh = refreshViewedConversationForExecutionLifecycle(
+        viewer, ['codex:session-a'], reconcile
+    );
+    await Promise.resolve();
+    currentTarget = {
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-b',
+    };
+    releaseReconcile();
+
+    assert.equal(await refresh, false);
+    assert.deepEqual(refreshes, [],
+        'a lifecycle edge for the previous session must not replace the newly selected reader');
+});
+
 test('CONVERSATION-WORKING-INDICATOR-001 delivers a completed viewed lifecycle through the Dashboard handler without refreshing for another session', async () => {
     const operations = [];
     const viewer = {

--- a/tests/integration/dashboard/conversationRouting.test.js
+++ b/tests/integration/dashboard/conversationRouting.test.js
@@ -906,14 +906,18 @@ test('PRODUCTION-CONVERSATION-LIFECYCLE-002 fire-and-forget reconcile isolates v
         'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         'private prompt',
     ].join(' ');
+    let reconcileAuthorityCalled = false;
     const harness = createDashboardConversationHarness({
         viewerReconcileAuthority: async () => {
+            reconcileAuthorityCalled = true;
             throw new Error(secret);
         },
     });
     await harness.activate();
 
     await assert.doesNotReject(harness.capability.reconcile());
+    assert.equal(reconcileAuthorityCalled, true,
+        'unscoped reconciliation must reach the injected authority failure');
     assert.deepEqual(harness.diagnostics, [{
         event: 'conversation-read',
         category: 'unavailable',

--- a/tests/integration/dashboard/conversationRouting.test.js
+++ b/tests/integration/dashboard/conversationRouting.test.js
@@ -324,7 +324,7 @@ function createDashboardConversationHarness(options = {}) {
         ...(options.useConcreteViewer
             ? {}
             : {
-                createViewer: () => {
+                createViewer: options.createViewer || (() => {
                     let disposed = false;
                     return {
                         isOpen: () => false,
@@ -341,7 +341,7 @@ function createDashboardConversationHarness(options = {}) {
                             events.push('dispose:viewer');
                         },
                     };
-                },
+                }),
             }),
     };
 
@@ -390,6 +390,7 @@ function createDashboardConversationHarness(options = {}) {
                 setTimer: (callback, delayMs) => setTimeout(callback, delayMs),
                 clearTimer: handle => clearTimeout(handle),
                 onDiagnostic: event => diagnostics.push(event),
+                resolveReboundTarget: options.resolveReboundTarget,
                 getWorkspaceRootHostPaths:
                     options.getWorkspaceRootHostPaths,
                 commentStore: options.commentStore,
@@ -859,6 +860,43 @@ test('PRODUCTION-CONVERSATION-LIFECYCLE-001 keeps the exact viewer authority lif
         ).at(-1).stale,
         false
     );
+    await harness.dispose();
+});
+
+test('CONVERSATION-WORKING-INDICATOR-001 scopes lifecycle reconciliation across a deferred session rebind', async () => {
+    let currentTarget = {
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+    };
+    let releaseRebind;
+    const calls = [];
+    const viewer = {
+        getCurrentTarget: () => currentTarget,
+        reconcileReboundSession: () => new Promise(resolve => {
+            releaseRebind = resolve;
+        }),
+        reconcileAuthority: async () => {
+            calls.push('reconcile-authority');
+        },
+        dispose() {},
+    };
+    const harness = createDashboardConversationHarness({
+        createViewer: () => viewer,
+        resolveReboundTarget: target => target,
+    });
+    await harness.activate();
+
+    const reconcile = harness.capability.reconcile({
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-a',
+    });
+    await Promise.resolve();
+    currentTarget = {
+        projectId: 'project-a', provider: 'codex', sessionId: 'session-b',
+    };
+    releaseRebind();
+
+    assert.equal(await reconcile, false);
+    assert.deepEqual(calls, [],
+        'an old lifecycle edge must not reconcile authority for the replacement session');
     await harness.dispose();
 });
 


### PR DESCRIPTION
## Summary

- Synchronize a restored Conversation with its matching execution lifecycle before applying the working-state refresh.
- Preserve lifecycle isolation through navigation and asynchronous session rebinds, without duplicate reader refreshes.
- Add lifecycle, Dashboard wiring, composition-race, browser, and behavior-contract regression coverage.

## Validation

- `npm run worktree:run -- npm run test:ci:linux`
- `npm run worktree:run -- env SKIP_NPM_CI=1 npm run install-local`
- Focused lifecycle and composition suites (75 tests)

## Skill harvest

No skill change: the existing regression and review workflows already prescribe RED tests, composition-level integration coverage, error-boundary checks, and final race review. This update followed those safeguards and strengthened their product coverage.

## Owner approvals

```text
approve 8e01ad7a4949b55f69a6cbe3fda73b7e32ea2d1a
```