### PR TITLE
Fix Conversation file links across workspace roots

### DIFF
--- a/scripts/run-extension-host-worker.js
+++ b/scripts/run-extension-host-worker.js
@@ -12,6 +12,45 @@ const {
     installPackagedExtensions,
 } = require('./lib/extensionHostLauncher');
 
+const VSCODE_DOWNLOAD_TIMEOUT_MS = 60_000;
+const VSCODE_DOWNLOAD_ATTEMPTS = 2;
+
+function isRetriableVSCodeDownloadError(error) {
+    if (!error) return false;
+    const retriableCodes = new Set([
+        'ECONNABORTED',
+        'ECONNRESET',
+        'ECONNREFUSED',
+        'EAI_AGAIN',
+        'ENETUNREACH',
+        'ETIMEDOUT',
+    ]);
+    if (retriableCodes.has(error.code)) return true;
+    if (Array.isArray(error.errors)
+        && error.errors.some(isRetriableVSCodeDownloadError)) return true;
+    return /@vscode\/test-electron request timeout/.test(String(error.message || error));
+}
+
+async function downloadVSCodeWithRetry(download, options, logger) {
+    for (let attempt = 1; attempt <= VSCODE_DOWNLOAD_ATTEMPTS; attempt += 1) {
+        try {
+            return await download({
+                ...options,
+                timeout: VSCODE_DOWNLOAD_TIMEOUT_MS,
+            });
+        } catch (error) {
+            if (!isRetriableVSCodeDownloadError(error)
+                || attempt === VSCODE_DOWNLOAD_ATTEMPTS) {
+                throw error;
+            }
+            logger.log(
+                `VS Code download attempt ${attempt} failed with a transient network error; retrying.`
+            );
+        }
+    }
+    throw new Error('VS Code download retry loop exited unexpectedly.');
+}
+
 function notifyParentOfCompletion(message) {
     if (typeof process.send !== 'function') return Promise.resolve();
     return new Promise((resolve, reject) => {
@@ -38,10 +77,10 @@ async function runExtensionHostWorker(repositoryRoot, environment, options = {})
     logger.log(
         `Installing release VSIX files into isolated VS Code ${version}.`
     );
-    const vscodeExecutablePath = await download({
+    const vscodeExecutablePath = await downloadVSCodeWithRetry(download, {
         version,
         extensionDevelopmentPath: repositoryRoot,
-    });
+    }, logger);
     const installation = install(
         repositoryRoot,
         environment,
@@ -81,6 +120,10 @@ if (require.main === module) {
 }
 
 module.exports = {
+    VSCODE_DOWNLOAD_ATTEMPTS,
+    VSCODE_DOWNLOAD_TIMEOUT_MS,
+    downloadVSCodeWithRetry,
+    isRetriableVSCodeDownloadError,
     main,
     runExtensionHostWorker,
 };

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1932,12 +1932,16 @@ async function initializeDashboard(
                 && authoritativeRoot.length > 0
                 ? [authoritativeRoot]
                 : [];
-            // A session with a persisted worktree/cwd must never fall through
-            // to a same-named file in the primary workspace. Only legacy
-            // sessions without an authoritative location use dashboard roots.
-            const roots = authoritativeRoots.length > 0
+            const workspaceRoots = actionTarget?.workspace.roots
+                .map(root => root.hostPath) || [];
+            // A relative reference must stay within the session's authoritative
+            // worktree/cwd when it has one: falling through could open a
+            // same-named primary-workspace file. An absolute reference already
+            // names its file, so it may also resolve inside another trusted
+            // workspace root (for example, a sibling code directory).
+            const roots = 'relativePath' in targetFile && authoritativeRoots.length > 0
                 ? authoritativeRoots
-                : actionTarget?.workspace.roots.map(root => root.hostPath) || [];
+                : [...authoritativeRoots, ...workspaceRoots];
             for (const rootPath of roots) {
                 let canonicalRoot: string;
                 try {

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -5422,6 +5422,19 @@ test('CONVERSATION-LOCAL-FILE-LINKS-001 routes absolute and workspace-relative f
     }], 'file resolution remains bound to the viewed conversation target');
 });
 
+test('CONVERSATION-LOCAL-FILE-LINKS-001 keeps absolute code locations reachable from the workspace when a Conversation is bound to a worktree', () => {
+    const dashboardSource = fs.readFileSync(
+        path.join(__dirname, '../../../src/dashboard.ts'),
+        'utf8'
+    );
+
+    assert.match(
+        dashboardSource,
+        /const roots = 'relativePath' in targetFile && authoritativeRoots\.length > 0\n\s*\? authoritativeRoots\n\s*:\s*\[\.\.\.authoritativeRoots, \.\.\.workspaceRoots\];/,
+        'relative links must stay scoped to the conversation worktree, while an exact absolute path may use every trusted workspace root'
+    );
+});
+
 test('WEBVIEW-AI-SESSION-CONVERSATION-VIEWER-001 routes one exact selection send to the active terminal inserter', async () => {
     const inserted = [];
     const { viewer, panel } = createViewer({

--- a/tests/unit/tooling/extensionHostWorker.test.js
+++ b/tests/unit/tooling/extensionHostWorker.test.js
@@ -4,6 +4,8 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 
 const {
+    VSCODE_DOWNLOAD_TIMEOUT_MS,
+    downloadVSCodeWithRetry,
     main,
     runExtensionHostWorker,
 } = require('../../../scripts/run-extension-host-worker');
@@ -67,6 +69,7 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 installs verified VSIX bytes before H
     assert.deepEqual(calls[0][1], {
         version: '9.8.7',
         extensionDevelopmentPath: '/repository',
+        timeout: VSCODE_DOWNLOAD_TIMEOUT_MS,
     });
     assert.deepEqual(calls[1].slice(1), [
         '/repository',
@@ -89,6 +92,35 @@ test('RELEASE-SCHEDULED-EXTENSION-HOST-001 installs verified VSIX bytes before H
     ]);
     assert.match(logs.join('\n'), /Verified installed .* verified-sha/);
     assert.match(logs.join('\n'), /Running installed Extension Host smoke/);
+});
+
+// RELEASE-SCHEDULED-EXTENSION-HOST-001
+test('RELEASE-SCHEDULED-EXTENSION-HOST-001 retries only transient VS Code download failures', async () => {
+    const logs = [];
+    let attempts = 0;
+    const executablePath = await downloadVSCodeWithRetry(async () => {
+        attempts += 1;
+        if (attempts === 1) {
+            throw new AggregateError([
+                Object.assign(new Error('connection timed out'), { code: 'ETIMEDOUT' }),
+            ], 'VS Code metadata request failed');
+        }
+        return '/downloaded/code';
+    }, { version: '9.8.7' }, { log: message => logs.push(message) });
+
+    assert.equal(executablePath, '/downloaded/code');
+    assert.equal(attempts, 2);
+    assert.match(logs.join('\n'), /transient network error; retrying/);
+
+    attempts = 0;
+    await assert.rejects(
+        downloadVSCodeWithRetry(async () => {
+            attempts += 1;
+            throw new Error('Invalid version 9.8.7');
+        }, { version: '9.8.7' }, { log: () => {} }),
+        /Invalid version 9.8.7/
+    );
+    assert.equal(attempts, 1, 'non-network download errors must not be retried');
 });
 
 // RELEASE-SCHEDULED-EXTENSION-HOST-001


### PR DESCRIPTION
## Summary

- Allow absolute Conversation file links to resolve in any trusted workspace root.
- Keep relative links bound to the authoritative session worktree.
- Retry only transient VS Code download failures in the Extension Host smoke test.

## Testing

- npm run test:behavior-contracts
- npm run test:integration
- node --test --test-concurrency=1 tests/browser/conversationViewer.test.js
- npm run install-local
- npm run test-compile
- node --test tests/unit/tooling/extensionHostWorker.test.js
- npm run lint

## Skill harvest

No skill update: active VS Code Server discovery and installed-byte verification are already covered by the local extension installation skill.

## Owner approvals

```
approve e120f074f91f438fec255c986acb00059f73cc43
```