### PR TITLE
perf: coalesce repeated window row clicks

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -2843,7 +2843,7 @@
   {
     "id": "OPEN-WINDOW-NAVIGATION-SETTLEMENT-001",
     "domain": "open-project",
-    "title": "Open-window navigation uses a versioned request/settlement protocol: every request carries requestId+cardId, settles exactly once (focused/stale-target/untitled-workspace/failed/malformed), records only aggregate outcome/duration plus timestamp-only rapid-correction diagnostics, and the webview ignores stale or duplicate receipts, supersedes consecutive clicks, times out into an inline error with retry, and replays pending/error state after authoritative DOM replacements",
+    "title": "Open-window navigation uses a versioned request/settlement protocol: every request carries requestId+cardId, settles exactly once (focused/stale-target/untitled-workspace/failed/malformed), records only aggregate outcome/duration plus timestamp-only rapid-correction diagnostics, and the webview ignores stale or duplicate receipts, coalesces consecutive same-row clicks without swallowing a later cross-row intent, times out into an inline error with retry, and replays pending/error state after authoritative DOM replacements",
     "priority": "P0",
     "status": "automated",
     "owners": [

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -1541,7 +1541,8 @@ function initProjectGroupCollapse() {
 // - settlements are matched by cardId + requestId, stale/duplicate receipts
 //   are ignored;
 // - consecutive requests on the same row share the existing pending request;
-// - a later cross-row intent may supersede an older pending request;
+// - after an intervening cross-row intent, returning to the original row may
+//   supersede its older pending request;
 // - requests time out into the error state;
 // - pending/error row state is replayed after authoritative DOM replacements.
 var agentPivotOpenWindowNavigation = (function () {

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -1540,7 +1540,8 @@ function initProjectGroupCollapse() {
 // - every request carries a fresh requestId and goes pending;
 // - settlements are matched by cardId + requestId, stale/duplicate receipts
 //   are ignored;
-// - consecutive requests on the same row supersede earlier pending ones;
+// - consecutive requests on the same row share the existing pending request;
+// - a later cross-row intent may supersede an older pending request;
 // - requests time out into the error state;
 // - pending/error row state is replayed after authoritative DOM replacements.
 var agentPivotOpenWindowNavigation = (function () {
@@ -1551,6 +1552,7 @@ var agentPivotOpenWindowNavigation = (function () {
     var VALID_OUTCOMES = ['focused', 'stale-target', 'untitled-workspace', 'failed', 'malformed-request'];
 
     var nextRequestId = 0;
+    var lastRequestedCardId = null;
     // cardId -> { requestId, timeoutHandle }
     var pendingByCardId = new Map();
     // cardId -> { outcome, requestId } (drives the row error state until the
@@ -1621,9 +1623,13 @@ var agentPivotOpenWindowNavigation = (function () {
             return;
         }
         var existing = pendingByCardId.get(cardId);
+        if (existing && lastRequestedCardId === cardId) {
+            return;
+        }
+        lastRequestedCardId = cardId;
         if (existing) {
-            // Consecutive clicks supersede: the old request's settlement is
-            // ignored when it arrives (requestId no longer matches).
+            // A-B-A preserves the final A intent: the intervening B makes
+            // this A distinct, so it supersedes the older pending A.
             clearPending(cardId, existing);
         }
         nextRequestId = nextRequestId >= Number.MAX_SAFE_INTEGER ? 1 : nextRequestId + 1;

--- a/media/webviewOpenWindowNavigationScripts.js
+++ b/media/webviewOpenWindowNavigationScripts.js
@@ -6,7 +6,8 @@
 // - every request carries a fresh requestId and goes pending;
 // - settlements are matched by cardId + requestId, stale/duplicate receipts
 //   are ignored;
-// - consecutive requests on the same row supersede earlier pending ones;
+// - consecutive requests on the same row share the existing pending request;
+// - a later cross-row intent may supersede an older pending request;
 // - requests time out into the error state;
 // - pending/error row state is replayed after authoritative DOM replacements.
 var agentPivotOpenWindowNavigation = (function () {
@@ -17,6 +18,7 @@ var agentPivotOpenWindowNavigation = (function () {
     var VALID_OUTCOMES = ['focused', 'stale-target', 'untitled-workspace', 'failed', 'malformed-request'];
 
     var nextRequestId = 0;
+    var lastRequestedCardId = null;
     // cardId -> { requestId, timeoutHandle }
     var pendingByCardId = new Map();
     // cardId -> { outcome, requestId } (drives the row error state until the
@@ -87,9 +89,13 @@ var agentPivotOpenWindowNavigation = (function () {
             return;
         }
         var existing = pendingByCardId.get(cardId);
+        if (existing && lastRequestedCardId === cardId) {
+            return;
+        }
+        lastRequestedCardId = cardId;
         if (existing) {
-            // Consecutive clicks supersede: the old request's settlement is
-            // ignored when it arrives (requestId no longer matches).
+            // A-B-A preserves the final A intent: the intervening B makes
+            // this A distinct, so it supersedes the older pending A.
             clearPending(cardId, existing);
         }
         nextRequestId = nextRequestId >= Number.MAX_SAFE_INTEGER ? 1 : nextRequestId + 1;

--- a/media/webviewOpenWindowNavigationScripts.js
+++ b/media/webviewOpenWindowNavigationScripts.js
@@ -7,7 +7,8 @@
 // - settlements are matched by cardId + requestId, stale/duplicate receipts
 //   are ignored;
 // - consecutive requests on the same row share the existing pending request;
-// - a later cross-row intent may supersede an older pending request;
+// - after an intervening cross-row intent, returning to the original row may
+//   supersede its older pending request;
 // - requests time out into the error state;
 // - pending/error row state is replayed after authoritative DOM replacements.
 var agentPivotOpenWindowNavigation = (function () {

--- a/src/webview/webviewOpenWindowNavigationScripts.js
+++ b/src/webview/webviewOpenWindowNavigationScripts.js
@@ -6,7 +6,8 @@
 // - every request carries a fresh requestId and goes pending;
 // - settlements are matched by cardId + requestId, stale/duplicate receipts
 //   are ignored;
-// - consecutive requests on the same row supersede earlier pending ones;
+// - consecutive requests on the same row share the existing pending request;
+// - a later cross-row intent may supersede an older pending request;
 // - requests time out into the error state;
 // - pending/error row state is replayed after authoritative DOM replacements.
 var agentPivotOpenWindowNavigation = (function () {
@@ -17,6 +18,7 @@ var agentPivotOpenWindowNavigation = (function () {
     var VALID_OUTCOMES = ['focused', 'stale-target', 'untitled-workspace', 'failed', 'malformed-request'];
 
     var nextRequestId = 0;
+    var lastRequestedCardId = null;
     // cardId -> { requestId, timeoutHandle }
     var pendingByCardId = new Map();
     // cardId -> { outcome, requestId } (drives the row error state until the
@@ -87,9 +89,13 @@ var agentPivotOpenWindowNavigation = (function () {
             return;
         }
         var existing = pendingByCardId.get(cardId);
+        if (existing && lastRequestedCardId === cardId) {
+            return;
+        }
+        lastRequestedCardId = cardId;
         if (existing) {
-            // Consecutive clicks supersede: the old request's settlement is
-            // ignored when it arrives (requestId no longer matches).
+            // A-B-A preserves the final A intent: the intervening B makes
+            // this A distinct, so it supersedes the older pending A.
             clearPending(cardId, existing);
         }
         nextRequestId = nextRequestId >= Number.MAX_SAFE_INTEGER ? 1 : nextRequestId + 1;

--- a/src/webview/webviewOpenWindowNavigationScripts.js
+++ b/src/webview/webviewOpenWindowNavigationScripts.js
@@ -7,7 +7,8 @@
 // - settlements are matched by cardId + requestId, stale/duplicate receipts
 //   are ignored;
 // - consecutive requests on the same row share the existing pending request;
-// - a later cross-row intent may supersede an older pending request;
+// - after an intervening cross-row intent, returning to the original row may
+//   supersede its older pending request;
 // - requests time out into the error state;
 // - pending/error row state is replayed after authoritative DOM replacements.
 var agentPivotOpenWindowNavigation = (function () {

--- a/tests/browser/dashboardWindowSwitcher.test.js
+++ b/tests/browser/dashboardWindowSwitcher.test.js
@@ -390,7 +390,7 @@ test('OPEN-WINDOW-NAVIGATION-SETTLEMENT-001 failure shows inline error and retry
     assert.equal(afterRetry.retryHidden, true);
 });
 
-test('OPEN-WINDOW-NAVIGATION-SETTLEMENT-001 consecutive clicks supersede and timeout fails the row', async t => {
+test('OPEN-WINDOW-NAVIGATION-SETTLEMENT-001 consecutive clicks coalesce without swallowing A-B-A', async t => {
     const page = await browser.newPage({ viewport: { width: 360, height: 600 } });
     t.after(() => page.close());
     page.setDefaultTimeout(BROWSER_CONDITION_TIMEOUT_MS);
@@ -414,12 +414,18 @@ test('OPEN-WINDOW-NAVIGATION-SETTLEMENT-001 consecutive clicks supersede and tim
         eval(source);
     }, navigationScript);
 
-    await page.evaluate(id => {
-        window.__agentPivotOpenWindowNavigation.request(id);
-        window.__agentPivotOpenWindowNavigation.request(id);
-    }, cardId);
-    assert.equal((await page.evaluate(() => window.__postedMessages)).length, 2);
-    assert.equal(await page.evaluate(() => window.__timeoutCallbacks.length), 2);
+    const otherCardId = '__openWorkspaceNavigation-' + 'c'.repeat(24);
+    await page.evaluate(({ cardId, otherCardId }) => {
+        window.__agentPivotOpenWindowNavigation.request(cardId);
+        window.__agentPivotOpenWindowNavigation.request(cardId);
+        window.__agentPivotOpenWindowNavigation.request(otherCardId);
+        window.__agentPivotOpenWindowNavigation.request(cardId);
+    }, { cardId, otherCardId });
+    const requests = await page.evaluate(() => window.__postedMessages);
+    assert.deepEqual(requests.map(request => request.cardId), [
+        cardId, otherCardId, cardId,
+    ], 'only a consecutive same-row click is coalesced; A-B-A preserves the final A intent');
+    assert.equal(await page.evaluate(() => window.__timeoutCallbacks.length), 3);
 
     // settlement for the superseded request is ignored
     await page.evaluate(id => {
@@ -429,9 +435,9 @@ test('OPEN-WINDOW-NAVIGATION-SETTLEMENT-001 consecutive clicks supersede and tim
     }, cardId);
     assert.equal(await page.evaluate(id => window.__agentPivotOpenWindowNavigation.isPending(id), cardId), true);
 
-    // fire the live timeout: the row settles into the error state
+    // fire the live timeout for the final A: the row settles into the error state
     await page.evaluate(() => {
-        window.__timeoutCallbacks[1]();
+        window.__timeoutCallbacks[2]();
     });
     const state = await page.evaluate(id => ({
         state: document.querySelector(`[data-open-window-row][data-id="${id}"]`).getAttribute('data-navigation-state'),
@@ -443,6 +449,12 @@ test('OPEN-WINDOW-NAVIGATION-SETTLEMENT-001 consecutive clicks supersede and tim
     assert.equal(state.outcome, 'failed');
     assert.equal(state.retryHidden, false);
     assert.equal(state.pending, false);
+
+    await page.evaluate(id => window.__agentPivotOpenWindowNavigation.retry(id), cardId);
+    const retried = await page.evaluate(() => window.__postedMessages.at(-1));
+    assert.equal(retried.cardId, cardId);
+    assert.equal(retried.requestId, 4,
+        'a timeout clears pending so Retry always sends a fresh request');
 });
 
 test('OPEN-WINDOW-SWITCHER-UI-001 state transitions do not shift row geometry', async t => {
@@ -727,6 +739,12 @@ test('OPEN-WINDOW-SWITCHER-UI-001 production OPEN tab routes row clicks and keep
         cardId: navigationCard.id,
     });
     assert.equal(await navigationRow.getAttribute('data-navigation-state'), 'pending');
+
+    await navigationRow.locator('[data-action="focus-open-window"]').click();
+    posted = await page.evaluate(() => window.__postedMessages);
+    requests = posted.filter(message => message.type === 'open-window-navigation-request');
+    assert.equal(requests.length, 1,
+        'a consecutive click on the same pending row must reuse the first request');
 
     // Clicking the current row is inert: no navigation request is posted.
     // (force: the button is aria-disabled, which is exactly the inertness


### PR DESCRIPTION
## Summary

- coalesce consecutive clicks on the same pending window row in the Webview
- preserve A-B-A latest intent and fresh retries after failure or timeout
- keep the Host controller, UI Bridge, and navigation protocol unchanged

## Verification

- `npm run worktree:run -- npm run test:dashboard`
- `npm run worktree:run -- node --test tests/browser/dashboardWindowSwitcher.test.js` (25 passed)
- `npm run worktree:run -- npm run test:behavior-contracts`
- `npm run worktree:run -- npm run test:open-projects`
- `git diff --check origin/main..HEAD`
- `SKIP_NPM_CI=1 CODE_CMD=<active-code-server> VSCODE_EXTENSIONS=<server-extensions> npm run worktree:run -- npm run install-local`
- packaged and byte-verified `agent-pivot-1.4.0.vsix` and `agent-pivot-attention-ui-bridge-1.0.3.vsix`

## Skill harvest

No skill change justified. The user correction was a task-specific design-scope adjustment; the existing Webview, review, local-install, and PR skills already cover retry lifecycle, source/media synchronization, installed-byte verification, and final review.

## Owner approvals

After reviewing this exact head, post:

```
approve efe19ced360c371585263d9d445e7dc737bbd6d8
```
