### PR TITLE
feat: edit Machines inline

### DIFF
--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -9524,11 +9524,15 @@ function createMachineProjectsUi() {
         if (open && hasPendingManagedMachineForm()) return;
         if (open) {
             panel.querySelectorAll('[data-managed-machine-form]').forEach(function (other) {
-                if (other !== form) other.hidden = true;
+                if (other !== form) {
+                    other.hidden = true;
+                    resetDismissedManagedMachineForm(other);
+                }
             });
             if (trigger) trigger.setAttribute('aria-expanded', 'false');
         }
         form.hidden = !open;
+        if (!open) resetDismissedManagedMachineForm(form);
         if (trigger && form.getAttribute('data-managed-machine-form-operation') === 'addMachine') {
             trigger.setAttribute('aria-expanded', String(open));
         }
@@ -9540,6 +9544,21 @@ function createMachineProjectsUi() {
                 ? trigger : form.closest('[data-machine-row]') && form.closest('[data-machine-row]').querySelector('.machine-row-primary');
             if (focusReturn && typeof focusReturn.focus === 'function') focusReturn.focus();
         }
+    }
+
+    function resetDismissedManagedMachineForm(form) {
+        if (form.getAttribute('data-managed-machine-form-operation') !== 'editMachine') return;
+        resetManagedMachineForm(form);
+    }
+
+    function resetManagedMachineForm(form) {
+        form.reset();
+        form.querySelectorAll('input[aria-invalid]').forEach(function (input) {
+            input.removeAttribute('aria-invalid');
+            input.removeAttribute('aria-describedby');
+        });
+        var error = form.querySelector('[data-managed-machine-form-error]');
+        if (error) { error.hidden = true; error.textContent = ''; }
     }
 
     function setAddMachineFormOpen(open, returnFocus) {
@@ -9558,17 +9577,66 @@ function createMachineProjectsUi() {
             port: Number(form.elements.port.value),
         };
         var error = form.querySelector('[data-managed-machine-form-error]');
-        var message = !isValidMachineName(values.name) ? 'Enter a Machine name of up to 128 characters.'
-            : !isValidHost(values.host) ? 'Enter a valid DNS name or IP address.'
-            : !isValidSshUser(values.user) ? 'Enter a valid SSH user.'
-            : !Number.isInteger(values.port) || values.port < 1 || values.port > 65535
-                ? 'Enter a port from 1 to 65535.' : '';
+        var invalidField = !isValidMachineName(values.name) ? 'name'
+            : !isValidHost(values.host) ? 'host'
+            : !isValidSshUser(values.user) ? 'user'
+            : !Number.isInteger(values.port) || values.port < 1 || values.port > 65535 ? 'port' : '';
+        var message = invalidField === 'name' ? 'Enter a Machine name of up to 128 characters.'
+            : invalidField === 'host' ? 'Enter a valid DNS name or IP address.'
+            : invalidField === 'user' ? 'Enter a valid SSH user.'
+            : invalidField === 'port' ? 'Enter a port from 1 to 65535.' : '';
         if (message) {
+            var invalidInput = form.elements[invalidField];
+            if (invalidInput) {
+                invalidInput.setAttribute('aria-invalid', 'true');
+                if (error && error.id) invalidInput.setAttribute('aria-describedby', error.id);
+                invalidInput.focus();
+            }
             if (error) { error.textContent = message; error.hidden = false; }
             return;
         }
+        form.querySelectorAll('input[aria-invalid]').forEach(function (input) {
+            input.removeAttribute('aria-invalid');
+            input.removeAttribute('aria-describedby');
+        });
         if (error) { error.hidden = true; error.textContent = ''; }
         postManagedAction(form.querySelector('[data-managed-operation]'), values);
+    }
+
+    function captureManagedMachineFormState() {
+        var form = Array.from(panel ? panel.querySelectorAll('[data-managed-machine-form]') : [])
+            .find(function (candidate) { return !candidate.hidden; });
+        if (!form) return null;
+        var activeElement = document.activeElement;
+        return {
+            operation: form.getAttribute('data-managed-machine-form-operation') || '',
+            targetId: form.getAttribute('data-managed-target-id') || '',
+            values: {
+                name: String(form.elements.name.value || ''),
+                host: String(form.elements.host.value || ''),
+                user: String(form.elements.user.value || ''),
+                port: String(form.elements.port.value || ''),
+            },
+            focusField: activeElement && form.contains(activeElement)
+                ? activeElement.getAttribute('name') || '' : '',
+        };
+    }
+
+    function restoreManagedMachineFormState(state) {
+        if (!state || (state.operation !== 'addMachine' && state.operation !== 'editMachine')
+            || !state.values) return;
+        var form = findManagedMachineForm(state.operation, state.targetId || '');
+        if (!form) return;
+        ['name', 'host', 'user', 'port'].forEach(function (field) {
+            if (typeof state.values[field] === 'string') form.elements[field].value = state.values[field];
+        });
+        form.hidden = false;
+        if (state.operation === 'addMachine') {
+            var trigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
+            if (trigger) trigger.setAttribute('aria-expanded', 'true');
+        }
+        var focusField = state.focusField && form.elements[state.focusField];
+        if (focusField && typeof focusField.focus === 'function') focusField.focus();
     }
 
     function isValidMachineName(value) {
@@ -9857,7 +9925,13 @@ function createMachineProjectsUi() {
 
     function onDocumentScroll(event) {
         if (!activeProjectMenuTrigger) return;
-        var row = activeProjectMenuTrigger.closest('[data-machine-project-row]');
+        var row = activeProjectMenuTrigger.closest(
+            '[data-machine-project-row], [data-machine-row]'
+        );
+        if (event.target === document
+            && activeProjectMenuTrigger.getAttribute('data-action') === 'toggle-machine-menu') {
+            return;
+        }
         if (!row || !row.contains(event.target)) closeProjectMenu(false);
     }
 
@@ -9882,6 +9956,15 @@ function createMachineProjectsUi() {
             false
         );
         if (message.status === 'applied') {
+            var submittedForm = findManagedMachineForm(pending.operation, pending.targetId);
+            if (submittedForm) {
+                submittedForm.hidden = true;
+                resetManagedMachineForm(submittedForm);
+                if (pending.operation === 'addMachine') {
+                    var addTrigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
+                    if (addTrigger) addTrigger.setAttribute('aria-expanded', 'false');
+                }
+            }
             if (pending.focusAddMachine) {
                 var trigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
                 if (trigger) trigger.focus();
@@ -9901,7 +9984,8 @@ function createMachineProjectsUi() {
                 var error = form.querySelector('[data-managed-machine-form-error]');
                 if (error) {
                     error.textContent = typeof message.message === 'string'
-                        ? message.message : 'Unable to add the Machine.';
+                        ? message.message : pending.operation === 'editMachine'
+                            ? 'Unable to save Machine changes.' : 'Unable to add the Machine.';
                     error.hidden = false;
                 }
             }
@@ -9938,6 +10022,8 @@ function createMachineProjectsUi() {
         isMounted: function () { return Boolean(panel); },
         getDisclosureCollapsedStates: getDisclosureCollapsedStates,
         setAllDisclosuresCollapsed: setAllDisclosuresCollapsed,
+        captureManagedMachineFormState: captureManagedMachineFormState,
+        restoreManagedMachineFormState: restoreManagedMachineFormState,
         applyTextFilter: function (value) {
             textQuery = String(value || '').trim().toLocaleLowerCase();
             applyFilters();
@@ -11421,6 +11507,10 @@ function captureProjectsPanelState(panel) {
             && typeof window.__agentPivotProjectInlineEdit.captureState === 'function'
             ? window.__agentPivotProjectInlineEdit.captureState()
             : null,
+        managedMachineForm: window.__agentPivotMachineProjects
+            && typeof window.__agentPivotMachineProjects.captureManagedMachineFormState === 'function'
+            ? window.__agentPivotMachineProjects.captureManagedMachineFormState()
+            : null,
         groups: Array.from(panel.querySelectorAll(
             '.group[data-group-id]'
         )).map(function (group) {
@@ -11986,6 +12076,12 @@ function createDashboardProjectsPanel(injected) {
         }
         restoreProjectsPanelAnchors(panels.projects, panelState);
         restoreProjectsFocus(panels.projects, panelState.focus);
+        if (panelState.managedMachineForm && window.__agentPivotMachineProjects
+            && typeof window.__agentPivotMachineProjects.restoreManagedMachineFormState === 'function') {
+            window.__agentPivotMachineProjects.restoreManagedMachineFormState(
+                panelState.managedMachineForm
+            );
+        }
         if (panelState.inlineEdit && window.__agentPivotProjectInlineEdit) {
             window.__agentPivotProjectInlineEdit.restoreState(panelState.inlineEdit);
         }

--- a/media/webviewDashboardBundle.js
+++ b/media/webviewDashboardBundle.js
@@ -9430,6 +9430,20 @@ function createMachineProjectsUi() {
             });
     }
 
+    function findManagedMachineForm(operation, targetId) {
+        if (!panel) return null;
+        return Array.from(panel.querySelectorAll('[data-managed-machine-form]')).find(function (form) {
+            return form.getAttribute('data-managed-machine-form-operation') === operation
+                && (form.getAttribute('data-managed-target-id') || '') === (targetId || '');
+        }) || null;
+    }
+
+    function hasPendingManagedMachineForm() {
+        return Array.from(pendingManagedActions.values()).some(function (pending) {
+            return pending.operation === 'addMachine' || pending.operation === 'editMachine';
+        });
+    }
+
     function setManagedControlsPending(operation, targetId, requestId, pending) {
         findManagedControls(operation, targetId).forEach(function (control) {
             if (pending) {
@@ -9440,8 +9454,8 @@ function createMachineProjectsUi() {
                 control.disabled = false;
             }
         });
-        if (operation === 'addMachine') {
-            var form = panel && panel.querySelector('[data-managed-machine-form]');
+        if (operation === 'addMachine' || operation === 'editMachine') {
+            var form = findManagedMachineForm(operation, targetId);
             if (form) {
                 form.setAttribute('aria-busy', String(pending));
                 form.querySelectorAll('input, button').forEach(function (item) { item.disabled = pending; });
@@ -9489,6 +9503,7 @@ function createMachineProjectsUi() {
             operation: operation,
             targetId: targetId,
             focusAddMachine: operation === 'addMachine',
+            focusEditedMachineId: operation === 'editMachine' ? targetId : '',
         });
         setManagedControlsPending(operation, targetId, requestId, true);
         announceManaged('Working…');
@@ -9503,21 +9518,39 @@ function createMachineProjectsUi() {
         });
     }
 
-    function setAddMachineFormOpen(open, returnFocus) {
-        var form = panel && panel.querySelector('[data-managed-machine-form]');
+    function setManagedMachineFormOpen(form, open, returnFocus) {
         var trigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
         if (!form || (!open && form.getAttribute('aria-busy') === 'true')) return;
+        if (open && hasPendingManagedMachineForm()) return;
+        if (open) {
+            panel.querySelectorAll('[data-managed-machine-form]').forEach(function (other) {
+                if (other !== form) other.hidden = true;
+            });
+            if (trigger) trigger.setAttribute('aria-expanded', 'false');
+        }
         form.hidden = !open;
-        if (trigger) trigger.setAttribute('aria-expanded', String(open));
+        if (trigger && form.getAttribute('data-managed-machine-form-operation') === 'addMachine') {
+            trigger.setAttribute('aria-expanded', String(open));
+        }
         if (open) {
             var name = form.elements.name;
             if (name && typeof name.focus === 'function') name.focus();
-        } else if (returnFocus && trigger && typeof trigger.focus === 'function') {
-            trigger.focus();
+        } else if (returnFocus) {
+            var focusReturn = form.getAttribute('data-managed-machine-form-operation') === 'addMachine'
+                ? trigger : form.closest('[data-machine-row]') && form.closest('[data-machine-row]').querySelector('.machine-row-primary');
+            if (focusReturn && typeof focusReturn.focus === 'function') focusReturn.focus();
         }
     }
 
-    function submitAddMachineForm(form) {
+    function setAddMachineFormOpen(open, returnFocus) {
+        setManagedMachineFormOpen(findManagedMachineForm('addMachine', ''), open, returnFocus);
+    }
+
+    function setEditMachineFormOpen(targetId, open, returnFocus) {
+        setManagedMachineFormOpen(findManagedMachineForm('editMachine', targetId), open, returnFocus);
+    }
+
+    function submitManagedMachineForm(form) {
         var values = {
             name: String(form.elements.name.value || '').trim(),
             host: String(form.elements.host.value || '').trim(),
@@ -9535,7 +9568,7 @@ function createMachineProjectsUi() {
             return;
         }
         if (error) { error.hidden = true; error.textContent = ''; }
-        postManagedAction(form.querySelector('[data-managed-operation="addMachine"]'), values);
+        postManagedAction(form.querySelector('[data-managed-operation]'), values);
     }
 
     function isValidMachineName(value) {
@@ -9633,8 +9666,13 @@ function createMachineProjectsUi() {
             setAddMachineFormOpen(true, false);
             return;
         }
-        if (control.getAttribute('data-action') === 'cancel-add-machine-form') {
-            setAddMachineFormOpen(false, true);
+        if (control.getAttribute('data-action') === 'show-edit-machine-form') {
+            closeProjectMenu(false);
+            setEditMachineFormOpen(control.getAttribute('data-managed-target-id') || '', true, false);
+            return;
+        }
+        if (control.getAttribute('data-action') === 'cancel-managed-machine-form') {
+            setManagedMachineFormOpen(control.closest('[data-managed-machine-form]'), false, true);
             return;
         }
         if (control.closest('[data-managed-machine-form]')) return;
@@ -9749,7 +9787,7 @@ function createMachineProjectsUi() {
             ? event.target.closest('[data-managed-machine-form]') : null;
         if (!form || !panel || !panel.contains(form)) return;
         event.preventDefault();
-        submitAddMachineForm(form);
+        submitManagedMachineForm(form);
     }
 
     function onKeyDown(event) {
@@ -9761,7 +9799,7 @@ function createMachineProjectsUi() {
         if (event.key === 'Escape' && event.target && event.target.closest
             && event.target.closest('[data-managed-machine-form]')) {
             event.preventDefault();
-            setAddMachineFormOpen(false, true);
+            setManagedMachineFormOpen(event.target.closest('[data-managed-machine-form]'), false, true);
             return;
         }
         var menu = event.target && event.target.closest
@@ -9847,13 +9885,19 @@ function createMachineProjectsUi() {
             if (pending.focusAddMachine) {
                 var trigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
                 if (trigger) trigger.focus();
+            } else if (pending.focusEditedMachineId) {
+                var editedMachine = panel && Array.from(panel.querySelectorAll('[data-machine-row]'))
+                    .find(function (row) { return row.getAttribute('data-machine-id') === pending.focusEditedMachineId; });
+                var editedFocus = editedMachine && editedMachine.querySelector('.machine-row-primary');
+                if (editedFocus) editedFocus.focus();
             }
             announceManaged('Changes saved to your VS Code User settings.');
         } else if (message.status === 'cancelled') {
             announceManaged('No changes were saved.');
         } else {
-            var form = panel && panel.querySelector('[data-managed-machine-form]');
-            if (pending.operation === 'addMachine' && form && !form.hidden) {
+            var form = findManagedMachineForm(pending.operation, pending.targetId);
+            if ((pending.operation === 'addMachine' || pending.operation === 'editMachine')
+                && form && !form.hidden) {
                 var error = form.querySelector('[data-managed-machine-form-error]');
                 if (error) {
                     error.textContent = typeof message.message === 'string'

--- a/media/webviewDashboardProjectsPanelScripts.js
+++ b/media/webviewDashboardProjectsPanelScripts.js
@@ -101,6 +101,12 @@ function createDashboardProjectsPanel(injected) {
         }
         restoreProjectsPanelAnchors(panels.projects, panelState);
         restoreProjectsFocus(panels.projects, panelState.focus);
+        if (panelState.managedMachineForm && window.__agentPivotMachineProjects
+            && typeof window.__agentPivotMachineProjects.restoreManagedMachineFormState === 'function') {
+            window.__agentPivotMachineProjects.restoreManagedMachineFormState(
+                panelState.managedMachineForm
+            );
+        }
         if (panelState.inlineEdit && window.__agentPivotProjectInlineEdit) {
             window.__agentPivotProjectInlineEdit.restoreState(panelState.inlineEdit);
         }

--- a/media/webviewMachineProjectsScripts.js
+++ b/media/webviewMachineProjectsScripts.js
@@ -396,11 +396,15 @@ function createMachineProjectsUi() {
         if (open && hasPendingManagedMachineForm()) return;
         if (open) {
             panel.querySelectorAll('[data-managed-machine-form]').forEach(function (other) {
-                if (other !== form) other.hidden = true;
+                if (other !== form) {
+                    other.hidden = true;
+                    resetDismissedManagedMachineForm(other);
+                }
             });
             if (trigger) trigger.setAttribute('aria-expanded', 'false');
         }
         form.hidden = !open;
+        if (!open) resetDismissedManagedMachineForm(form);
         if (trigger && form.getAttribute('data-managed-machine-form-operation') === 'addMachine') {
             trigger.setAttribute('aria-expanded', String(open));
         }
@@ -412,6 +416,21 @@ function createMachineProjectsUi() {
                 ? trigger : form.closest('[data-machine-row]') && form.closest('[data-machine-row]').querySelector('.machine-row-primary');
             if (focusReturn && typeof focusReturn.focus === 'function') focusReturn.focus();
         }
+    }
+
+    function resetDismissedManagedMachineForm(form) {
+        if (form.getAttribute('data-managed-machine-form-operation') !== 'editMachine') return;
+        resetManagedMachineForm(form);
+    }
+
+    function resetManagedMachineForm(form) {
+        form.reset();
+        form.querySelectorAll('input[aria-invalid]').forEach(function (input) {
+            input.removeAttribute('aria-invalid');
+            input.removeAttribute('aria-describedby');
+        });
+        var error = form.querySelector('[data-managed-machine-form-error]');
+        if (error) { error.hidden = true; error.textContent = ''; }
     }
 
     function setAddMachineFormOpen(open, returnFocus) {
@@ -430,17 +449,66 @@ function createMachineProjectsUi() {
             port: Number(form.elements.port.value),
         };
         var error = form.querySelector('[data-managed-machine-form-error]');
-        var message = !isValidMachineName(values.name) ? 'Enter a Machine name of up to 128 characters.'
-            : !isValidHost(values.host) ? 'Enter a valid DNS name or IP address.'
-            : !isValidSshUser(values.user) ? 'Enter a valid SSH user.'
-            : !Number.isInteger(values.port) || values.port < 1 || values.port > 65535
-                ? 'Enter a port from 1 to 65535.' : '';
+        var invalidField = !isValidMachineName(values.name) ? 'name'
+            : !isValidHost(values.host) ? 'host'
+            : !isValidSshUser(values.user) ? 'user'
+            : !Number.isInteger(values.port) || values.port < 1 || values.port > 65535 ? 'port' : '';
+        var message = invalidField === 'name' ? 'Enter a Machine name of up to 128 characters.'
+            : invalidField === 'host' ? 'Enter a valid DNS name or IP address.'
+            : invalidField === 'user' ? 'Enter a valid SSH user.'
+            : invalidField === 'port' ? 'Enter a port from 1 to 65535.' : '';
         if (message) {
+            var invalidInput = form.elements[invalidField];
+            if (invalidInput) {
+                invalidInput.setAttribute('aria-invalid', 'true');
+                if (error && error.id) invalidInput.setAttribute('aria-describedby', error.id);
+                invalidInput.focus();
+            }
             if (error) { error.textContent = message; error.hidden = false; }
             return;
         }
+        form.querySelectorAll('input[aria-invalid]').forEach(function (input) {
+            input.removeAttribute('aria-invalid');
+            input.removeAttribute('aria-describedby');
+        });
         if (error) { error.hidden = true; error.textContent = ''; }
         postManagedAction(form.querySelector('[data-managed-operation]'), values);
+    }
+
+    function captureManagedMachineFormState() {
+        var form = Array.from(panel ? panel.querySelectorAll('[data-managed-machine-form]') : [])
+            .find(function (candidate) { return !candidate.hidden; });
+        if (!form) return null;
+        var activeElement = document.activeElement;
+        return {
+            operation: form.getAttribute('data-managed-machine-form-operation') || '',
+            targetId: form.getAttribute('data-managed-target-id') || '',
+            values: {
+                name: String(form.elements.name.value || ''),
+                host: String(form.elements.host.value || ''),
+                user: String(form.elements.user.value || ''),
+                port: String(form.elements.port.value || ''),
+            },
+            focusField: activeElement && form.contains(activeElement)
+                ? activeElement.getAttribute('name') || '' : '',
+        };
+    }
+
+    function restoreManagedMachineFormState(state) {
+        if (!state || (state.operation !== 'addMachine' && state.operation !== 'editMachine')
+            || !state.values) return;
+        var form = findManagedMachineForm(state.operation, state.targetId || '');
+        if (!form) return;
+        ['name', 'host', 'user', 'port'].forEach(function (field) {
+            if (typeof state.values[field] === 'string') form.elements[field].value = state.values[field];
+        });
+        form.hidden = false;
+        if (state.operation === 'addMachine') {
+            var trigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
+            if (trigger) trigger.setAttribute('aria-expanded', 'true');
+        }
+        var focusField = state.focusField && form.elements[state.focusField];
+        if (focusField && typeof focusField.focus === 'function') focusField.focus();
     }
 
     function isValidMachineName(value) {
@@ -729,7 +797,13 @@ function createMachineProjectsUi() {
 
     function onDocumentScroll(event) {
         if (!activeProjectMenuTrigger) return;
-        var row = activeProjectMenuTrigger.closest('[data-machine-project-row]');
+        var row = activeProjectMenuTrigger.closest(
+            '[data-machine-project-row], [data-machine-row]'
+        );
+        if (event.target === document
+            && activeProjectMenuTrigger.getAttribute('data-action') === 'toggle-machine-menu') {
+            return;
+        }
         if (!row || !row.contains(event.target)) closeProjectMenu(false);
     }
 
@@ -754,6 +828,15 @@ function createMachineProjectsUi() {
             false
         );
         if (message.status === 'applied') {
+            var submittedForm = findManagedMachineForm(pending.operation, pending.targetId);
+            if (submittedForm) {
+                submittedForm.hidden = true;
+                resetManagedMachineForm(submittedForm);
+                if (pending.operation === 'addMachine') {
+                    var addTrigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
+                    if (addTrigger) addTrigger.setAttribute('aria-expanded', 'false');
+                }
+            }
             if (pending.focusAddMachine) {
                 var trigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
                 if (trigger) trigger.focus();
@@ -773,7 +856,8 @@ function createMachineProjectsUi() {
                 var error = form.querySelector('[data-managed-machine-form-error]');
                 if (error) {
                     error.textContent = typeof message.message === 'string'
-                        ? message.message : 'Unable to add the Machine.';
+                        ? message.message : pending.operation === 'editMachine'
+                            ? 'Unable to save Machine changes.' : 'Unable to add the Machine.';
                     error.hidden = false;
                 }
             }
@@ -810,6 +894,8 @@ function createMachineProjectsUi() {
         isMounted: function () { return Boolean(panel); },
         getDisclosureCollapsedStates: getDisclosureCollapsedStates,
         setAllDisclosuresCollapsed: setAllDisclosuresCollapsed,
+        captureManagedMachineFormState: captureManagedMachineFormState,
+        restoreManagedMachineFormState: restoreManagedMachineFormState,
         applyTextFilter: function (value) {
             textQuery = String(value || '').trim().toLocaleLowerCase();
             applyFilters();

--- a/media/webviewMachineProjectsScripts.js
+++ b/media/webviewMachineProjectsScripts.js
@@ -302,6 +302,20 @@ function createMachineProjectsUi() {
             });
     }
 
+    function findManagedMachineForm(operation, targetId) {
+        if (!panel) return null;
+        return Array.from(panel.querySelectorAll('[data-managed-machine-form]')).find(function (form) {
+            return form.getAttribute('data-managed-machine-form-operation') === operation
+                && (form.getAttribute('data-managed-target-id') || '') === (targetId || '');
+        }) || null;
+    }
+
+    function hasPendingManagedMachineForm() {
+        return Array.from(pendingManagedActions.values()).some(function (pending) {
+            return pending.operation === 'addMachine' || pending.operation === 'editMachine';
+        });
+    }
+
     function setManagedControlsPending(operation, targetId, requestId, pending) {
         findManagedControls(operation, targetId).forEach(function (control) {
             if (pending) {
@@ -312,8 +326,8 @@ function createMachineProjectsUi() {
                 control.disabled = false;
             }
         });
-        if (operation === 'addMachine') {
-            var form = panel && panel.querySelector('[data-managed-machine-form]');
+        if (operation === 'addMachine' || operation === 'editMachine') {
+            var form = findManagedMachineForm(operation, targetId);
             if (form) {
                 form.setAttribute('aria-busy', String(pending));
                 form.querySelectorAll('input, button').forEach(function (item) { item.disabled = pending; });
@@ -361,6 +375,7 @@ function createMachineProjectsUi() {
             operation: operation,
             targetId: targetId,
             focusAddMachine: operation === 'addMachine',
+            focusEditedMachineId: operation === 'editMachine' ? targetId : '',
         });
         setManagedControlsPending(operation, targetId, requestId, true);
         announceManaged('Working…');
@@ -375,21 +390,39 @@ function createMachineProjectsUi() {
         });
     }
 
-    function setAddMachineFormOpen(open, returnFocus) {
-        var form = panel && panel.querySelector('[data-managed-machine-form]');
+    function setManagedMachineFormOpen(form, open, returnFocus) {
         var trigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
         if (!form || (!open && form.getAttribute('aria-busy') === 'true')) return;
+        if (open && hasPendingManagedMachineForm()) return;
+        if (open) {
+            panel.querySelectorAll('[data-managed-machine-form]').forEach(function (other) {
+                if (other !== form) other.hidden = true;
+            });
+            if (trigger) trigger.setAttribute('aria-expanded', 'false');
+        }
         form.hidden = !open;
-        if (trigger) trigger.setAttribute('aria-expanded', String(open));
+        if (trigger && form.getAttribute('data-managed-machine-form-operation') === 'addMachine') {
+            trigger.setAttribute('aria-expanded', String(open));
+        }
         if (open) {
             var name = form.elements.name;
             if (name && typeof name.focus === 'function') name.focus();
-        } else if (returnFocus && trigger && typeof trigger.focus === 'function') {
-            trigger.focus();
+        } else if (returnFocus) {
+            var focusReturn = form.getAttribute('data-managed-machine-form-operation') === 'addMachine'
+                ? trigger : form.closest('[data-machine-row]') && form.closest('[data-machine-row]').querySelector('.machine-row-primary');
+            if (focusReturn && typeof focusReturn.focus === 'function') focusReturn.focus();
         }
     }
 
-    function submitAddMachineForm(form) {
+    function setAddMachineFormOpen(open, returnFocus) {
+        setManagedMachineFormOpen(findManagedMachineForm('addMachine', ''), open, returnFocus);
+    }
+
+    function setEditMachineFormOpen(targetId, open, returnFocus) {
+        setManagedMachineFormOpen(findManagedMachineForm('editMachine', targetId), open, returnFocus);
+    }
+
+    function submitManagedMachineForm(form) {
         var values = {
             name: String(form.elements.name.value || '').trim(),
             host: String(form.elements.host.value || '').trim(),
@@ -407,7 +440,7 @@ function createMachineProjectsUi() {
             return;
         }
         if (error) { error.hidden = true; error.textContent = ''; }
-        postManagedAction(form.querySelector('[data-managed-operation="addMachine"]'), values);
+        postManagedAction(form.querySelector('[data-managed-operation]'), values);
     }
 
     function isValidMachineName(value) {
@@ -505,8 +538,13 @@ function createMachineProjectsUi() {
             setAddMachineFormOpen(true, false);
             return;
         }
-        if (control.getAttribute('data-action') === 'cancel-add-machine-form') {
-            setAddMachineFormOpen(false, true);
+        if (control.getAttribute('data-action') === 'show-edit-machine-form') {
+            closeProjectMenu(false);
+            setEditMachineFormOpen(control.getAttribute('data-managed-target-id') || '', true, false);
+            return;
+        }
+        if (control.getAttribute('data-action') === 'cancel-managed-machine-form') {
+            setManagedMachineFormOpen(control.closest('[data-managed-machine-form]'), false, true);
             return;
         }
         if (control.closest('[data-managed-machine-form]')) return;
@@ -621,7 +659,7 @@ function createMachineProjectsUi() {
             ? event.target.closest('[data-managed-machine-form]') : null;
         if (!form || !panel || !panel.contains(form)) return;
         event.preventDefault();
-        submitAddMachineForm(form);
+        submitManagedMachineForm(form);
     }
 
     function onKeyDown(event) {
@@ -633,7 +671,7 @@ function createMachineProjectsUi() {
         if (event.key === 'Escape' && event.target && event.target.closest
             && event.target.closest('[data-managed-machine-form]')) {
             event.preventDefault();
-            setAddMachineFormOpen(false, true);
+            setManagedMachineFormOpen(event.target.closest('[data-managed-machine-form]'), false, true);
             return;
         }
         var menu = event.target && event.target.closest
@@ -719,13 +757,19 @@ function createMachineProjectsUi() {
             if (pending.focusAddMachine) {
                 var trigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
                 if (trigger) trigger.focus();
+            } else if (pending.focusEditedMachineId) {
+                var editedMachine = panel && Array.from(panel.querySelectorAll('[data-machine-row]'))
+                    .find(function (row) { return row.getAttribute('data-machine-id') === pending.focusEditedMachineId; });
+                var editedFocus = editedMachine && editedMachine.querySelector('.machine-row-primary');
+                if (editedFocus) editedFocus.focus();
             }
             announceManaged('Changes saved to your VS Code User settings.');
         } else if (message.status === 'cancelled') {
             announceManaged('No changes were saved.');
         } else {
-            var form = panel && panel.querySelector('[data-managed-machine-form]');
-            if (pending.operation === 'addMachine' && form && !form.hidden) {
+            var form = findManagedMachineForm(pending.operation, pending.targetId);
+            if ((pending.operation === 'addMachine' || pending.operation === 'editMachine')
+                && form && !form.hidden) {
                 var error = form.querySelector('[data-managed-machine-form-error]');
                 if (error) {
                     error.textContent = typeof message.message === 'string'

--- a/media/webviewProjectsPanelScripts.js
+++ b/media/webviewProjectsPanelScripts.js
@@ -92,6 +92,10 @@ function captureProjectsPanelState(panel) {
             && typeof window.__agentPivotProjectInlineEdit.captureState === 'function'
             ? window.__agentPivotProjectInlineEdit.captureState()
             : null,
+        managedMachineForm: window.__agentPivotMachineProjects
+            && typeof window.__agentPivotMachineProjects.captureManagedMachineFormState === 'function'
+            ? window.__agentPivotMachineProjects.captureManagedMachineFormState()
+            : null,
         groups: Array.from(panel.querySelectorAll(
             '.group[data-group-id]'
         )).map(function (group) {

--- a/src/projects/managedRemote/managementController.ts
+++ b/src/projects/managedRemote/managementController.ts
@@ -208,12 +208,12 @@ export class ManagedRemoteManagementController {
         if (!targetId) { throw new Error('The Managed Remote target is missing.'); }
         if (operation === 'editMachine') {
             const machine = findMachine(snapshot, targetId);
-            const input = await this.options.prompts.editMachine(
+            const machineInput = input || await this.options.prompts.editMachine(
                 machine,
                 affectedProjectCount(snapshot, targetId),
             );
-            return input
-                ? this.options.store.editMachine(snapshot.revisionId, targetId, input) : null;
+            return machineInput
+                ? this.options.store.editMachine(snapshot.revisionId, targetId, machineInput) : null;
         }
         if (operation === 'removeMachine') {
             const machine = findMachine(snapshot, targetId);

--- a/src/projects/managedRemote/managementProtocol.ts
+++ b/src/projects/managedRemote/managementProtocol.ts
@@ -123,7 +123,7 @@ export function parseManagedRemoteManagementRequest(
         'type', 'version', 'requestId', 'operation', 'expectedRevisionId',
     ];
     const acceptsTarget = TARGET_OPERATIONS.has(operation) || operation === 'addProject';
-    const acceptsInput = operation === 'addMachine';
+    const acceptsInput = operation === 'addMachine' || operation === 'editMachine';
     const allowedKeys = [
         ...requiredKeys,
         ...(acceptsTarget ? ['targetId'] : []),

--- a/src/webview/webviewDashboardProjectsPanelScripts.js
+++ b/src/webview/webviewDashboardProjectsPanelScripts.js
@@ -101,6 +101,12 @@ function createDashboardProjectsPanel(injected) {
         }
         restoreProjectsPanelAnchors(panels.projects, panelState);
         restoreProjectsFocus(panels.projects, panelState.focus);
+        if (panelState.managedMachineForm && window.__agentPivotMachineProjects
+            && typeof window.__agentPivotMachineProjects.restoreManagedMachineFormState === 'function') {
+            window.__agentPivotMachineProjects.restoreManagedMachineFormState(
+                panelState.managedMachineForm
+            );
+        }
         if (panelState.inlineEdit && window.__agentPivotProjectInlineEdit) {
             window.__agentPivotProjectInlineEdit.restoreState(panelState.inlineEdit);
         }

--- a/src/webview/webviewMachineProjectsScripts.js
+++ b/src/webview/webviewMachineProjectsScripts.js
@@ -396,11 +396,15 @@ function createMachineProjectsUi() {
         if (open && hasPendingManagedMachineForm()) return;
         if (open) {
             panel.querySelectorAll('[data-managed-machine-form]').forEach(function (other) {
-                if (other !== form) other.hidden = true;
+                if (other !== form) {
+                    other.hidden = true;
+                    resetDismissedManagedMachineForm(other);
+                }
             });
             if (trigger) trigger.setAttribute('aria-expanded', 'false');
         }
         form.hidden = !open;
+        if (!open) resetDismissedManagedMachineForm(form);
         if (trigger && form.getAttribute('data-managed-machine-form-operation') === 'addMachine') {
             trigger.setAttribute('aria-expanded', String(open));
         }
@@ -412,6 +416,21 @@ function createMachineProjectsUi() {
                 ? trigger : form.closest('[data-machine-row]') && form.closest('[data-machine-row]').querySelector('.machine-row-primary');
             if (focusReturn && typeof focusReturn.focus === 'function') focusReturn.focus();
         }
+    }
+
+    function resetDismissedManagedMachineForm(form) {
+        if (form.getAttribute('data-managed-machine-form-operation') !== 'editMachine') return;
+        resetManagedMachineForm(form);
+    }
+
+    function resetManagedMachineForm(form) {
+        form.reset();
+        form.querySelectorAll('input[aria-invalid]').forEach(function (input) {
+            input.removeAttribute('aria-invalid');
+            input.removeAttribute('aria-describedby');
+        });
+        var error = form.querySelector('[data-managed-machine-form-error]');
+        if (error) { error.hidden = true; error.textContent = ''; }
     }
 
     function setAddMachineFormOpen(open, returnFocus) {
@@ -430,17 +449,66 @@ function createMachineProjectsUi() {
             port: Number(form.elements.port.value),
         };
         var error = form.querySelector('[data-managed-machine-form-error]');
-        var message = !isValidMachineName(values.name) ? 'Enter a Machine name of up to 128 characters.'
-            : !isValidHost(values.host) ? 'Enter a valid DNS name or IP address.'
-            : !isValidSshUser(values.user) ? 'Enter a valid SSH user.'
-            : !Number.isInteger(values.port) || values.port < 1 || values.port > 65535
-                ? 'Enter a port from 1 to 65535.' : '';
+        var invalidField = !isValidMachineName(values.name) ? 'name'
+            : !isValidHost(values.host) ? 'host'
+            : !isValidSshUser(values.user) ? 'user'
+            : !Number.isInteger(values.port) || values.port < 1 || values.port > 65535 ? 'port' : '';
+        var message = invalidField === 'name' ? 'Enter a Machine name of up to 128 characters.'
+            : invalidField === 'host' ? 'Enter a valid DNS name or IP address.'
+            : invalidField === 'user' ? 'Enter a valid SSH user.'
+            : invalidField === 'port' ? 'Enter a port from 1 to 65535.' : '';
         if (message) {
+            var invalidInput = form.elements[invalidField];
+            if (invalidInput) {
+                invalidInput.setAttribute('aria-invalid', 'true');
+                if (error && error.id) invalidInput.setAttribute('aria-describedby', error.id);
+                invalidInput.focus();
+            }
             if (error) { error.textContent = message; error.hidden = false; }
             return;
         }
+        form.querySelectorAll('input[aria-invalid]').forEach(function (input) {
+            input.removeAttribute('aria-invalid');
+            input.removeAttribute('aria-describedby');
+        });
         if (error) { error.hidden = true; error.textContent = ''; }
         postManagedAction(form.querySelector('[data-managed-operation]'), values);
+    }
+
+    function captureManagedMachineFormState() {
+        var form = Array.from(panel ? panel.querySelectorAll('[data-managed-machine-form]') : [])
+            .find(function (candidate) { return !candidate.hidden; });
+        if (!form) return null;
+        var activeElement = document.activeElement;
+        return {
+            operation: form.getAttribute('data-managed-machine-form-operation') || '',
+            targetId: form.getAttribute('data-managed-target-id') || '',
+            values: {
+                name: String(form.elements.name.value || ''),
+                host: String(form.elements.host.value || ''),
+                user: String(form.elements.user.value || ''),
+                port: String(form.elements.port.value || ''),
+            },
+            focusField: activeElement && form.contains(activeElement)
+                ? activeElement.getAttribute('name') || '' : '',
+        };
+    }
+
+    function restoreManagedMachineFormState(state) {
+        if (!state || (state.operation !== 'addMachine' && state.operation !== 'editMachine')
+            || !state.values) return;
+        var form = findManagedMachineForm(state.operation, state.targetId || '');
+        if (!form) return;
+        ['name', 'host', 'user', 'port'].forEach(function (field) {
+            if (typeof state.values[field] === 'string') form.elements[field].value = state.values[field];
+        });
+        form.hidden = false;
+        if (state.operation === 'addMachine') {
+            var trigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
+            if (trigger) trigger.setAttribute('aria-expanded', 'true');
+        }
+        var focusField = state.focusField && form.elements[state.focusField];
+        if (focusField && typeof focusField.focus === 'function') focusField.focus();
     }
 
     function isValidMachineName(value) {
@@ -729,7 +797,13 @@ function createMachineProjectsUi() {
 
     function onDocumentScroll(event) {
         if (!activeProjectMenuTrigger) return;
-        var row = activeProjectMenuTrigger.closest('[data-machine-project-row]');
+        var row = activeProjectMenuTrigger.closest(
+            '[data-machine-project-row], [data-machine-row]'
+        );
+        if (event.target === document
+            && activeProjectMenuTrigger.getAttribute('data-action') === 'toggle-machine-menu') {
+            return;
+        }
         if (!row || !row.contains(event.target)) closeProjectMenu(false);
     }
 
@@ -754,6 +828,15 @@ function createMachineProjectsUi() {
             false
         );
         if (message.status === 'applied') {
+            var submittedForm = findManagedMachineForm(pending.operation, pending.targetId);
+            if (submittedForm) {
+                submittedForm.hidden = true;
+                resetManagedMachineForm(submittedForm);
+                if (pending.operation === 'addMachine') {
+                    var addTrigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
+                    if (addTrigger) addTrigger.setAttribute('aria-expanded', 'false');
+                }
+            }
             if (pending.focusAddMachine) {
                 var trigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
                 if (trigger) trigger.focus();
@@ -773,7 +856,8 @@ function createMachineProjectsUi() {
                 var error = form.querySelector('[data-managed-machine-form-error]');
                 if (error) {
                     error.textContent = typeof message.message === 'string'
-                        ? message.message : 'Unable to add the Machine.';
+                        ? message.message : pending.operation === 'editMachine'
+                            ? 'Unable to save Machine changes.' : 'Unable to add the Machine.';
                     error.hidden = false;
                 }
             }
@@ -810,6 +894,8 @@ function createMachineProjectsUi() {
         isMounted: function () { return Boolean(panel); },
         getDisclosureCollapsedStates: getDisclosureCollapsedStates,
         setAllDisclosuresCollapsed: setAllDisclosuresCollapsed,
+        captureManagedMachineFormState: captureManagedMachineFormState,
+        restoreManagedMachineFormState: restoreManagedMachineFormState,
         applyTextFilter: function (value) {
             textQuery = String(value || '').trim().toLocaleLowerCase();
             applyFilters();

--- a/src/webview/webviewMachineProjectsScripts.js
+++ b/src/webview/webviewMachineProjectsScripts.js
@@ -302,6 +302,20 @@ function createMachineProjectsUi() {
             });
     }
 
+    function findManagedMachineForm(operation, targetId) {
+        if (!panel) return null;
+        return Array.from(panel.querySelectorAll('[data-managed-machine-form]')).find(function (form) {
+            return form.getAttribute('data-managed-machine-form-operation') === operation
+                && (form.getAttribute('data-managed-target-id') || '') === (targetId || '');
+        }) || null;
+    }
+
+    function hasPendingManagedMachineForm() {
+        return Array.from(pendingManagedActions.values()).some(function (pending) {
+            return pending.operation === 'addMachine' || pending.operation === 'editMachine';
+        });
+    }
+
     function setManagedControlsPending(operation, targetId, requestId, pending) {
         findManagedControls(operation, targetId).forEach(function (control) {
             if (pending) {
@@ -312,8 +326,8 @@ function createMachineProjectsUi() {
                 control.disabled = false;
             }
         });
-        if (operation === 'addMachine') {
-            var form = panel && panel.querySelector('[data-managed-machine-form]');
+        if (operation === 'addMachine' || operation === 'editMachine') {
+            var form = findManagedMachineForm(operation, targetId);
             if (form) {
                 form.setAttribute('aria-busy', String(pending));
                 form.querySelectorAll('input, button').forEach(function (item) { item.disabled = pending; });
@@ -361,6 +375,7 @@ function createMachineProjectsUi() {
             operation: operation,
             targetId: targetId,
             focusAddMachine: operation === 'addMachine',
+            focusEditedMachineId: operation === 'editMachine' ? targetId : '',
         });
         setManagedControlsPending(operation, targetId, requestId, true);
         announceManaged('Working…');
@@ -375,21 +390,39 @@ function createMachineProjectsUi() {
         });
     }
 
-    function setAddMachineFormOpen(open, returnFocus) {
-        var form = panel && panel.querySelector('[data-managed-machine-form]');
+    function setManagedMachineFormOpen(form, open, returnFocus) {
         var trigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
         if (!form || (!open && form.getAttribute('aria-busy') === 'true')) return;
+        if (open && hasPendingManagedMachineForm()) return;
+        if (open) {
+            panel.querySelectorAll('[data-managed-machine-form]').forEach(function (other) {
+                if (other !== form) other.hidden = true;
+            });
+            if (trigger) trigger.setAttribute('aria-expanded', 'false');
+        }
         form.hidden = !open;
-        if (trigger) trigger.setAttribute('aria-expanded', String(open));
+        if (trigger && form.getAttribute('data-managed-machine-form-operation') === 'addMachine') {
+            trigger.setAttribute('aria-expanded', String(open));
+        }
         if (open) {
             var name = form.elements.name;
             if (name && typeof name.focus === 'function') name.focus();
-        } else if (returnFocus && trigger && typeof trigger.focus === 'function') {
-            trigger.focus();
+        } else if (returnFocus) {
+            var focusReturn = form.getAttribute('data-managed-machine-form-operation') === 'addMachine'
+                ? trigger : form.closest('[data-machine-row]') && form.closest('[data-machine-row]').querySelector('.machine-row-primary');
+            if (focusReturn && typeof focusReturn.focus === 'function') focusReturn.focus();
         }
     }
 
-    function submitAddMachineForm(form) {
+    function setAddMachineFormOpen(open, returnFocus) {
+        setManagedMachineFormOpen(findManagedMachineForm('addMachine', ''), open, returnFocus);
+    }
+
+    function setEditMachineFormOpen(targetId, open, returnFocus) {
+        setManagedMachineFormOpen(findManagedMachineForm('editMachine', targetId), open, returnFocus);
+    }
+
+    function submitManagedMachineForm(form) {
         var values = {
             name: String(form.elements.name.value || '').trim(),
             host: String(form.elements.host.value || '').trim(),
@@ -407,7 +440,7 @@ function createMachineProjectsUi() {
             return;
         }
         if (error) { error.hidden = true; error.textContent = ''; }
-        postManagedAction(form.querySelector('[data-managed-operation="addMachine"]'), values);
+        postManagedAction(form.querySelector('[data-managed-operation]'), values);
     }
 
     function isValidMachineName(value) {
@@ -505,8 +538,13 @@ function createMachineProjectsUi() {
             setAddMachineFormOpen(true, false);
             return;
         }
-        if (control.getAttribute('data-action') === 'cancel-add-machine-form') {
-            setAddMachineFormOpen(false, true);
+        if (control.getAttribute('data-action') === 'show-edit-machine-form') {
+            closeProjectMenu(false);
+            setEditMachineFormOpen(control.getAttribute('data-managed-target-id') || '', true, false);
+            return;
+        }
+        if (control.getAttribute('data-action') === 'cancel-managed-machine-form') {
+            setManagedMachineFormOpen(control.closest('[data-managed-machine-form]'), false, true);
             return;
         }
         if (control.closest('[data-managed-machine-form]')) return;
@@ -621,7 +659,7 @@ function createMachineProjectsUi() {
             ? event.target.closest('[data-managed-machine-form]') : null;
         if (!form || !panel || !panel.contains(form)) return;
         event.preventDefault();
-        submitAddMachineForm(form);
+        submitManagedMachineForm(form);
     }
 
     function onKeyDown(event) {
@@ -633,7 +671,7 @@ function createMachineProjectsUi() {
         if (event.key === 'Escape' && event.target && event.target.closest
             && event.target.closest('[data-managed-machine-form]')) {
             event.preventDefault();
-            setAddMachineFormOpen(false, true);
+            setManagedMachineFormOpen(event.target.closest('[data-managed-machine-form]'), false, true);
             return;
         }
         var menu = event.target && event.target.closest
@@ -719,13 +757,19 @@ function createMachineProjectsUi() {
             if (pending.focusAddMachine) {
                 var trigger = panel && panel.querySelector('[data-action="show-add-machine-form"]');
                 if (trigger) trigger.focus();
+            } else if (pending.focusEditedMachineId) {
+                var editedMachine = panel && Array.from(panel.querySelectorAll('[data-machine-row]'))
+                    .find(function (row) { return row.getAttribute('data-machine-id') === pending.focusEditedMachineId; });
+                var editedFocus = editedMachine && editedMachine.querySelector('.machine-row-primary');
+                if (editedFocus) editedFocus.focus();
             }
             announceManaged('Changes saved to your VS Code User settings.');
         } else if (message.status === 'cancelled') {
             announceManaged('No changes were saved.');
         } else {
-            var form = panel && panel.querySelector('[data-managed-machine-form]');
-            if (pending.operation === 'addMachine' && form && !form.hidden) {
+            var form = findManagedMachineForm(pending.operation, pending.targetId);
+            if ((pending.operation === 'addMachine' || pending.operation === 'editMachine')
+                && form && !form.hidden) {
                 var error = form.querySelector('[data-managed-machine-form-error]');
                 if (error) {
                     error.textContent = typeof message.message === 'string'

--- a/src/webview/webviewManagedRemoteProjectsContent.ts
+++ b/src/webview/webviewManagedRemoteProjectsContent.ts
@@ -33,7 +33,7 @@ function renderTagControls(tags: string[]): string {
 }
 
 function renderAddMachineForm(): string {
-    return `<form id="managed-machine-form" class="managed-machine-form" data-managed-machine-form hidden>
+    return `<form id="managed-machine-form" class="managed-machine-form" data-managed-machine-form data-managed-machine-form-operation="addMachine" hidden>
         <div class="managed-machine-form-heading"><strong>Add Machine</strong><span>Connection details are saved to your VS Code User settings.</span></div>
         <div class="managed-machine-form-fields">
             <label>Machine name<input name="name" autocomplete="off" required maxlength="128" placeholder="Build server"></label>
@@ -42,7 +42,22 @@ function renderAddMachineForm(): string {
             <label>Port<input name="port" type="number" inputmode="numeric" required min="1" max="65535" value="22"></label>
         </div>
         <p class="managed-machine-form-error" data-managed-machine-form-error role="alert" hidden></p>
-        <div class="managed-machine-form-actions"><button type="button" class="machine-clear-filters" data-action="cancel-add-machine-form">Cancel</button><button type="submit" class="managed-machine-form-submit" data-managed-operation="addMachine">Add Machine</button></div>
+        <div class="managed-machine-form-actions"><button type="button" class="machine-clear-filters" data-action="cancel-managed-machine-form">Cancel</button><button type="submit" class="managed-machine-form-submit" data-managed-operation="addMachine">Add Machine</button></div>
+    </form>`;
+}
+
+function renderEditMachineForm(machine: ManagedRemoteMachineViewModel): string {
+    const projectLabel = `${machine.projectCount} Project${machine.projectCount === 1 ? '' : 's'}`;
+    return `<form id="managed-machine-edit-form-${escapeAttribute(machine.id)}" class="managed-machine-form managed-machine-edit-form" data-managed-machine-form data-managed-machine-form-operation="editMachine" data-managed-target-id="${escapeAttribute(machine.id)}" hidden>
+        <div class="managed-machine-form-heading"><strong>Edit ${escapeAttribute(machine.name)}</strong><span>Changing this connection affects ${projectLabel}.</span></div>
+        <div class="managed-machine-form-fields">
+            <label>Machine name<input name="name" autocomplete="off" required maxlength="128" value="${escapeAttribute(machine.name)}"></label>
+            <label>Host<input name="host" autocomplete="off" required maxlength="253" value="${escapeAttribute(machine.connection.host)}"></label>
+            <label>SSH user<input name="user" autocomplete="username" required maxlength="256" value="${escapeAttribute(machine.connection.user)}"></label>
+            <label>Port<input name="port" type="number" inputmode="numeric" required min="1" max="65535" value="${machine.connection.port}"></label>
+        </div>
+        <p class="managed-machine-form-error" data-managed-machine-form-error role="alert" hidden></p>
+        <div class="managed-machine-form-actions"><button type="button" class="machine-clear-filters" data-action="cancel-managed-machine-form">Cancel</button><button type="submit" class="managed-machine-form-submit" data-managed-operation="editMachine" data-managed-target-id="${escapeAttribute(machine.id)}">Save changes</button></div>
     </form>`;
 }
 
@@ -98,7 +113,7 @@ function renderMachine(
                 <button type="button" class="machine-pointer-action machine-primary-action" data-managed-client-action="openMachine" data-managed-target-id="${escapeAttribute(machine.id)}" aria-label="${escapeAttribute(machine.openable ? openName : `${openName}. Unavailable: ${machine.unavailableReason}`)}" title="${escapeAttribute(openName)}"${machine.openable ? '' : ' disabled'}>${Icons.openNewWindow}</button>
                 <div class="machine-project-menu-shell"><button type="button" class="machine-pointer-action machine-more-action" data-action="toggle-machine-menu" aria-label="More actions for ${escapeAttribute(`${machine.name}, ${machine.endpoint}`)}" title="More actions" aria-haspopup="menu" aria-expanded="false">${Icons.moreActions}</button><div class="machine-project-menu" data-machine-project-menu role="menu" hidden>
                     <button type="button" role="menuitem" tabindex="-1" ${operationAttributes('addProject', machine.id)}>Add Project…</button>
-                    <button type="button" role="menuitem" tabindex="-1" ${operationAttributes('editMachine', machine.id)}>Edit Machine…</button>
+                    <button type="button" role="menuitem" tabindex="-1" data-action="show-edit-machine-form" data-managed-target-id="${escapeAttribute(machine.id)}">Edit Machine…</button>
                     ${machine.conflict ? `<button type="button" role="menuitem" tabindex="-1" ${operationAttributes('resolveMachineConflict', machine.id)}>Review Connection Conflict…</button>` : ''}
                     <button type="button" role="menuitem" tabindex="-1" data-managed-client-action="sshTerminal" data-managed-target-id="${escapeAttribute(machine.id)}"${machine.openable ? '' : ' disabled'}>Open SSH Terminal…</button>
                     <button type="button" role="menuitem" tabindex="-1" data-managed-client-action="copySsh" data-managed-target-id="${escapeAttribute(machine.id)}"${machine.openable ? '' : ' disabled'}>Copy SSH Command</button>
@@ -106,6 +121,7 @@ function renderMachine(
                 </div></div>
             </div>
         </div>
+        ${renderEditMachineForm(machine)}
         ${machine.conflict ? '<div class="managed-remote-row-status">Connection conflict — Review</div>' : ''}
         <ul id="${childrenId}" class="machine-environment-list">${machine.environments.map(environment => renderEnvironment(environment)).join('\n')}</ul>
     </li>`;

--- a/src/webview/webviewManagedRemoteProjectsContent.ts
+++ b/src/webview/webviewManagedRemoteProjectsContent.ts
@@ -41,7 +41,7 @@ function renderAddMachineForm(): string {
             <label>SSH user<input name="user" autocomplete="username" required maxlength="256" placeholder="developer"></label>
             <label>Port<input name="port" type="number" inputmode="numeric" required min="1" max="65535" value="22"></label>
         </div>
-        <p class="managed-machine-form-error" data-managed-machine-form-error role="alert" hidden></p>
+        <p id="managed-add-machine-form-error" class="managed-machine-form-error" data-managed-machine-form-error role="alert" hidden></p>
         <div class="managed-machine-form-actions"><button type="button" class="machine-clear-filters" data-action="cancel-managed-machine-form">Cancel</button><button type="submit" class="managed-machine-form-submit" data-managed-operation="addMachine">Add Machine</button></div>
     </form>`;
 }
@@ -56,7 +56,7 @@ function renderEditMachineForm(machine: ManagedRemoteMachineViewModel): string {
             <label>SSH user<input name="user" autocomplete="username" required maxlength="256" value="${escapeAttribute(machine.connection.user)}"></label>
             <label>Port<input name="port" type="number" inputmode="numeric" required min="1" max="65535" value="${machine.connection.port}"></label>
         </div>
-        <p class="managed-machine-form-error" data-managed-machine-form-error role="alert" hidden></p>
+        <p id="managed-edit-machine-form-error-${escapeAttribute(machine.id)}" class="managed-machine-form-error" data-managed-machine-form-error role="alert" hidden></p>
         <div class="managed-machine-form-actions"><button type="button" class="machine-clear-filters" data-action="cancel-managed-machine-form">Cancel</button><button type="submit" class="managed-machine-form-submit" data-managed-operation="editMachine" data-managed-target-id="${escapeAttribute(machine.id)}">Save changes</button></div>
     </form>`;
 }

--- a/src/webview/webviewProjectsPanelScripts.js
+++ b/src/webview/webviewProjectsPanelScripts.js
@@ -92,6 +92,10 @@ function captureProjectsPanelState(panel) {
             && typeof window.__agentPivotProjectInlineEdit.captureState === 'function'
             ? window.__agentPivotProjectInlineEdit.captureState()
             : null,
+        managedMachineForm: window.__agentPivotMachineProjects
+            && typeof window.__agentPivotMachineProjects.captureManagedMachineFormState === 'function'
+            ? window.__agentPivotMachineProjects.captureManagedMachineFormState()
+            : null,
         groups: Array.from(panel.querySelectorAll(
             '.group[data-group-id]'
         )).map(function (group) {

--- a/tests/browser/machineProjects.test.js
+++ b/tests/browser/machineProjects.test.js
@@ -383,14 +383,14 @@ test('MACHINE-PROJECTS-NARROW-001 avoids horizontal scrolling at 260px', async t
 test('MANAGED-REMOTE-MANAGEMENT-003 posts revisioned actions and settles after replacement', async t => {
     const page = await openPage(t, 360, managedMarkup());
     await page.click('[data-action="show-add-machine-form"]');
-    assert.equal(await page.locator('[data-managed-machine-form]').isVisible(), true);
-    assert.equal(await page.locator('[data-managed-machine-form] input[name="name"]')
+    assert.equal(await page.locator('[data-managed-machine-form-operation="addMachine"]').isVisible(), true);
+    assert.equal(await page.locator('[data-managed-machine-form-operation="addMachine"] input[name="name"]')
         .evaluate(node => document.activeElement === node), true);
-    await page.locator('[data-managed-machine-form] input[name="name"]').fill('Build');
-    await page.locator('[data-managed-machine-form] input[name="host"]').fill('build.example.com');
-    await page.locator('[data-managed-machine-form] input[name="user"]').fill('dev');
-    await page.locator('[data-managed-machine-form] input[name="port"]').fill('22022');
-    await page.locator('[data-managed-machine-form]').evaluate(form => form.requestSubmit());
+    await page.locator('[data-managed-machine-form-operation="addMachine"] input[name="name"]').fill('Build');
+    await page.locator('[data-managed-machine-form-operation="addMachine"] input[name="host"]').fill('build.example.com');
+    await page.locator('[data-managed-machine-form-operation="addMachine"] input[name="user"]').fill('dev');
+    await page.locator('[data-managed-machine-form-operation="addMachine"] input[name="port"]').fill('22022');
+    await page.locator('[data-managed-machine-form-operation="addMachine"]').evaluate(form => form.requestSubmit());
     const request = await page.evaluate(() => window.messages.at(-1));
     assert.equal(request.type, 'managed-remote-action');
     assert.equal(request.version, 1);
@@ -402,7 +402,7 @@ test('MANAGED-REMOTE-MANAGEMENT-003 posts revisioned actions and settles after r
     });
     assert.equal(await page.locator('[data-managed-operation="addMachine"]').isDisabled(), true);
     await page.keyboard.press('Escape');
-    assert.equal(await page.locator('[data-managed-machine-form]').isVisible(), true,
+    assert.equal(await page.locator('[data-managed-machine-form-operation="addMachine"]').isVisible(), true,
         'Escape must not hide a form whose add request is still pending');
 
     await page.evaluate(({ html, requestId }) => {
@@ -424,19 +424,19 @@ test('MANAGED-REMOTE-MANAGEMENT-003 posts revisioned actions and settles after r
 test('MANAGED-REMOTE-MANAGEMENT-003 validates inline Machine drafts before posting', async t => {
     const page = await openPage(t, 260, managedMarkup());
     await page.click('[data-action="show-add-machine-form"]');
-    const fieldPositions = await page.locator('[data-managed-machine-form] input').evaluateAll(inputs =>
+    const fieldPositions = await page.locator('[data-managed-machine-form-operation="addMachine"] input').evaluateAll(inputs =>
         inputs.map(input => input.getBoundingClientRect().top),
     );
     assert.ok(fieldPositions.every((top, index) => index === 0 || top > fieldPositions[index - 1]),
         'each Machine input must occupy its own row');
-    await page.locator('[data-managed-machine-form] input[name="name"]').fill('Build');
-    await page.locator('[data-managed-machine-form] input[name="host"]').fill('not a host');
-    await page.locator('[data-managed-machine-form] input[name="user"]').fill('dev');
-    await page.locator('[data-managed-machine-form]').evaluate(form => form.requestSubmit());
+    await page.locator('[data-managed-machine-form-operation="addMachine"] input[name="name"]').fill('Build');
+    await page.locator('[data-managed-machine-form-operation="addMachine"] input[name="host"]').fill('not a host');
+    await page.locator('[data-managed-machine-form-operation="addMachine"] input[name="user"]').fill('dev');
+    await page.locator('[data-managed-machine-form-operation="addMachine"]').evaluate(form => form.requestSubmit());
     assert.equal(await page.evaluate(() => window.messages.length), 0);
-    assert.equal(await page.locator('[data-managed-machine-form-error]').textContent(),
+    assert.equal(await page.locator('[data-managed-machine-form-operation="addMachine"] [data-managed-machine-form-error]').textContent(),
         'Enter a valid DNS name or IP address.');
-    const geometry = await page.locator('[data-managed-machine-form]').evaluate(form => ({
+    const geometry = await page.locator('[data-managed-machine-form-operation="addMachine"]').evaluate(form => ({
         scrollWidth: form.scrollWidth,
         clientWidth: form.clientWidth,
     }));
@@ -455,23 +455,52 @@ test('MANAGED-REMOTE-MANAGEMENT-003 keeps direct management without a migration 
     assert.equal(await page.locator('[data-action="open-machine-project"]').first().isEnabled(), true);
 });
 
-test('MANAGED-REMOTE-MANAGEMENT-003 keeps row-menu focus stable while a mutation is pending', async t => {
+test('MANAGED-REMOTE-MANAGEMENT-003 edits a Machine inline and restores focus after replacement', async t => {
     const page = await openPage(t, 360, managedMarkup());
+    await page.click('[data-action="show-add-machine-form"]');
+    assert.equal(await page.locator('[data-managed-machine-form-operation="addMachine"]').isVisible(), true);
     await page.click('[data-machine-row] [data-action="toggle-machine-menu"]');
     await page.getByRole('menuitem', { name: 'Edit Machine…' }).click();
-    const request = await page.evaluate(() => window.messages.at(-1));
-    assert.equal(request.operation, 'editMachine');
+    const form = page.locator('[data-managed-machine-form-operation="editMachine"]');
+    assert.equal(await form.isVisible(), true);
+    assert.equal(await page.locator('[data-managed-machine-form-operation="addMachine"]').isHidden(), true,
+        'opening a Machine edit must close the Add Machine form');
+    assert.equal(await form.locator('input[name="name"]').inputValue(), 'Build');
+    assert.equal(await form.locator('input[name="host"]').inputValue(), 'build.example.com');
+    assert.equal(await form.getByText('Changing this connection affects 1 Project.').count(), 1);
+    assert.equal(await form.locator('input[name="name"]').evaluate(node => document.activeElement === node), true);
+    await form.getByRole('button', { name: 'Cancel' }).click();
+    assert.equal(await form.isHidden(), true);
     assert.equal(await page.locator('[data-machine-row] .machine-row-primary')
         .evaluate(node => document.activeElement === node), true);
 
-    await page.evaluate(requestId => {
+    await page.click('[data-machine-row] [data-action="toggle-machine-menu"]');
+    await page.getByRole('menuitem', { name: 'Edit Machine…' }).click();
+    await form.locator('input[name="name"]').fill('Build 2');
+    await form.locator('input[name="host"]').fill('next.example.com');
+    await form.locator('input[name="user"]').fill('ops');
+    await form.locator('input[name="port"]').fill('22023');
+    await form.evaluate(node => node.requestSubmit());
+    const request = await page.evaluate(() => window.messages.at(-1));
+    assert.equal(request.operation, 'editMachine');
+    assert.equal(request.targetId, 'machine:managed');
+    assert.deepEqual(request.input, {
+        name: 'Build 2', host: 'next.example.com', user: 'ops', port: 22023,
+    });
+    assert.equal(await form.locator('button[type="submit"]').isDisabled(), true);
+    await page.keyboard.press('Escape');
+    assert.equal(await form.isVisible(), true, 'Escape must not hide a pending Machine edit');
+
+    await page.evaluate(({ html, requestId }) => {
+        document.getElementById('panel').innerHTML = html;
+        window.machineUi.mount(document.getElementById('panel'));
         window.dispatchEvent(new MessageEvent('message', { data: {
             type: 'managed-remote-settlement', version: 1, requestId,
-            operation: 'editMachine', status: 'cancelled',
+            operation: 'editMachine', status: 'applied',
         } }));
-    }, request.requestId);
-    assert.equal(await page.locator('[data-machine-projects-announcer]').textContent(),
-        'No changes were saved.');
+    }, { html: managedMarkup(), requestId: request.requestId });
+    assert.equal(await page.locator('[data-machine-row] .machine-row-primary')
+        .evaluate(node => document.activeElement === node), true);
 });
 
 test('MANAGED-REMOTE-SSH-COMMAND-001 sends a strict row-menu SSH identity intent', async t => {

--- a/tests/browser/machineProjects.test.js
+++ b/tests/browser/machineProjects.test.js
@@ -414,6 +414,8 @@ test('MANAGED-REMOTE-MANAGEMENT-003 posts revisioned actions and settles after r
         } }));
     }, { html: managedMarkup(), requestId: request.requestId });
     assert.equal(await page.locator('[data-managed-operation="addMachine"]').isEnabled(), true);
+    assert.equal(await page.locator('[data-managed-machine-form-operation="addMachine"]').isHidden(), true,
+        'a successful add must close the preserved inline form');
     assert.equal(await page.locator('[data-action="show-add-machine-form"]')
         .evaluate(node => document.activeElement === node), true,
     'the replacement panel must return focus to Add Machine after a successful add');
@@ -436,6 +438,10 @@ test('MANAGED-REMOTE-MANAGEMENT-003 validates inline Machine drafts before posti
     assert.equal(await page.evaluate(() => window.messages.length), 0);
     assert.equal(await page.locator('[data-managed-machine-form-operation="addMachine"] [data-managed-machine-form-error]').textContent(),
         'Enter a valid DNS name or IP address.');
+    const invalidHost = page.locator('[data-managed-machine-form-operation="addMachine"] input[name="host"]');
+    assert.equal(await invalidHost.getAttribute('aria-invalid'), 'true');
+    assert.equal(await invalidHost.getAttribute('aria-describedby'), 'managed-add-machine-form-error');
+    assert.equal(await invalidHost.evaluate(node => document.activeElement === node), true);
     const geometry = await page.locator('[data-managed-machine-form-operation="addMachine"]').evaluate(form => ({
         scrollWidth: form.scrollWidth,
         clientWidth: form.clientWidth,
@@ -469,6 +475,7 @@ test('MANAGED-REMOTE-MANAGEMENT-003 edits a Machine inline and restores focus af
     assert.equal(await form.locator('input[name="host"]').inputValue(), 'build.example.com');
     assert.equal(await form.getByText('Changing this connection affects 1 Project.').count(), 1);
     assert.equal(await form.locator('input[name="name"]').evaluate(node => document.activeElement === node), true);
+    await form.locator('input[name="name"]').fill('Cancelled draft');
     await form.getByRole('button', { name: 'Cancel' }).click();
     assert.equal(await form.isHidden(), true);
     assert.equal(await page.locator('[data-machine-row] .machine-row-primary')
@@ -476,6 +483,27 @@ test('MANAGED-REMOTE-MANAGEMENT-003 edits a Machine inline and restores focus af
 
     await page.click('[data-machine-row] [data-action="toggle-machine-menu"]');
     await page.getByRole('menuitem', { name: 'Edit Machine…' }).click();
+    assert.equal(await form.locator('input[name="name"]').inputValue(), 'Build',
+        'Cancel must discard an unsaved edit draft');
+    await form.locator('input[name="name"]').fill('Escaped draft');
+    await page.keyboard.press('Escape');
+    await page.click('[data-machine-row] [data-action="toggle-machine-menu"]');
+    await page.getByRole('menuitem', { name: 'Edit Machine…' }).click();
+    assert.equal(await form.locator('input[name="name"]').inputValue(), 'Build',
+        'Escape must discard an unsaved edit draft');
+    await form.locator('input[name="name"]').fill('Replacement draft');
+    await page.evaluate(html => {
+        const panel = document.getElementById('panel');
+        const state = captureProjectsPanelState(panel);
+        panel.innerHTML = html;
+        window.machineUi.mount(panel);
+        restoreProjectsFocus(panel, state.focus);
+        window.machineUi.restoreManagedMachineFormState(state.managedMachineForm);
+    }, managedMarkup());
+    assert.equal(await form.isVisible(), true,
+        'an authoritative replacement must retain an open Machine edit');
+    assert.equal(await form.locator('input[name="name"]').inputValue(), 'Replacement draft');
+    assert.equal(await form.locator('input[name="name"]').evaluate(node => document.activeElement === node), true);
     await form.locator('input[name="name"]').fill('Build 2');
     await form.locator('input[name="host"]').fill('next.example.com');
     await form.locator('input[name="user"]').fill('ops');
@@ -491,16 +519,44 @@ test('MANAGED-REMOTE-MANAGEMENT-003 edits a Machine inline and restores focus af
     await page.keyboard.press('Escape');
     assert.equal(await form.isVisible(), true, 'Escape must not hide a pending Machine edit');
 
-    await page.evaluate(({ html, requestId }) => {
-        document.getElementById('panel').innerHTML = html;
-        window.machineUi.mount(document.getElementById('panel'));
+    await page.evaluate(html => {
+        const panel = document.getElementById('panel');
+        const state = captureProjectsPanelState(panel);
+        panel.innerHTML = html;
+        window.machineUi.mount(panel);
+        restoreProjectsFocus(panel, state.focus);
+        window.machineUi.restoreManagedMachineFormState(state.managedMachineForm);
+    }, managedMarkup());
+    assert.equal(await form.isVisible(), true,
+        'a pending edit must stay visible through an authoritative replacement');
+    assert.equal(await form.locator('button[type="submit"]').isDisabled(), true);
+    await page.evaluate(requestId => {
         window.dispatchEvent(new MessageEvent('message', { data: {
             type: 'managed-remote-settlement', version: 1, requestId,
             operation: 'editMachine', status: 'applied',
         } }));
-    }, { html: managedMarkup(), requestId: request.requestId });
+    }, request.requestId);
+    assert.equal(await form.isHidden(), true,
+        'a successful edit must close the preserved inline form');
     assert.equal(await page.locator('[data-machine-row] .machine-row-primary')
         .evaluate(node => document.activeElement === node), true);
+});
+
+test('MANAGED-REMOTE-MANAGEMENT-003 reports an edit-specific fallback error', async t => {
+    const page = await openPage(t, 360, managedMarkup());
+    await page.click('[data-machine-row] [data-action="toggle-machine-menu"]');
+    await page.getByRole('menuitem', { name: 'Edit Machine…' }).click();
+    const form = page.locator('[data-managed-machine-form-operation="editMachine"]');
+    await form.evaluate(node => node.requestSubmit());
+    const request = await page.evaluate(() => window.messages.at(-1));
+    await page.evaluate(requestId => {
+        window.dispatchEvent(new MessageEvent('message', { data: {
+            type: 'managed-remote-settlement', version: 1, requestId,
+            operation: 'editMachine', status: 'failed',
+        } }));
+    }, request.requestId);
+    assert.equal(await form.locator('[data-managed-machine-form-error]').textContent(),
+        'Unable to save Machine changes.');
 });
 
 test('MANAGED-REMOTE-SSH-COMMAND-001 sends a strict row-menu SSH identity intent', async t => {

--- a/tests/contract/projects/managedRemoteManagementController.test.js
+++ b/tests/contract/projects/managedRemoteManagementController.test.js
@@ -131,6 +131,19 @@ test('MANAGED-REMOTE-MANAGEMENT-001 uses a validated inline Machine draft withou
     }]);
 });
 
+test('MANAGED-REMOTE-MANAGEMENT-001 edits a Machine from a validated inline draft', async () => {
+    const { controller, calls } = fixture({
+        prompts: { async editMachine() { throw new Error('prompt must not open'); } },
+    });
+    await controller.handle({
+        ...request('editMachine', 'machine:one'),
+        input: { name: 'Build 2', host: 'next.example.com', user: 'ops', port: 22023 },
+    });
+    assert.deepEqual(calls[0], ['editMachine', revisionId, 'machine:one', {
+        name: 'Build 2', host: 'next.example.com', user: 'ops', port: 22023,
+    }]);
+});
+
 test('MANAGED-REMOTE-MANAGEMENT-001 resolves targets from the authoritative snapshot', async () => {
     const seen = [];
     const { controller, calls } = fixture({

--- a/tests/contract/projects/managedRemoteManagementProtocol.test.js
+++ b/tests/contract/projects/managedRemoteManagementProtocol.test.js
@@ -38,6 +38,11 @@ test('MANAGED-REMOTE-MANAGEMENT-001 accepts strict management intents and a boun
         expectedRevisionId: null,
         input: { name: ' Build ', host: ' build.example.com ', user: ' dev ', port: 22022 },
     }).input, { name: 'Build', host: 'build.example.com', user: 'dev', port: 22022 });
+    assert.deepEqual(parseManagedRemoteManagementRequest({
+        type: 'managed-remote-action', version: 1, requestId, operation: 'editMachine',
+        expectedRevisionId: null, targetId: 'machine:one',
+        input: { name: ' Build ', host: ' build.example.com ', user: ' dev ', port: 22022 },
+    }).input, { name: 'Build', host: 'build.example.com', user: 'dev', port: 22022 });
     assert.ok(parseManagedRemoteManagementRequest({
         type: 'managed-remote-action',
         version: 1,

--- a/tests/unit/webview/managedRemoteProjectsRendering.test.js
+++ b/tests/unit/webview/managedRemoteProjectsRendering.test.js
@@ -41,6 +41,8 @@ test('MANAGED-REMOTE-MANAGEMENT-003 renders complete management actions and no M
     assert.equal((html.match(/data-managed-operation="addProject"/gu) || []).length, 1);
     assert.match(html, /data-managed-operation="addProject" data-managed-target-id="machine:build"/u);
     assert.match(html, /data-managed-operation="editMachine"/);
+    assert.match(html, /data-action="show-edit-machine-form" data-managed-target-id="machine:build"/u);
+    assert.match(html, /Changing this connection affects 1 Project\./u);
     assert.match(html, /data-managed-operation="removeMachine"/);
     assert.match(html, /data-managed-operation="editProject"/);
     assert.match(html, /data-managed-operation="removeProject"/);


### PR DESCRIPTION
## Summary

- replace the Machine edit prompt with an inline, prefilled connection form
- preserve drafts, focus, and pending state through authoritative panel replacements
- validate edit inputs and keep the Machine actions menu reachable beside an open form

## Verification

- npm run test-compile
- npx gulp --production
- managed Remote protocol, controller, and rendering tests
- machine Projects and dashboard bootstrap browser tests
- node scripts/run-dashboard-webview-checks.js

## Skill harvest

No skill change: the review findings were covered by the existing replacement-lifecycle and final-integration-review guidance; this PR applies those rules and adds regression coverage.

## Owner approvals

```
approve 3ba797e2e46bfc4f81b6e2c554faf2dd7b2b85db
```