### PR TITLE
test: stabilize conversation viewer acknowledgement

### DIFF
--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -1054,9 +1054,13 @@ test('CONVERSATION-QUESTION-NAVIGATION-001 applies a true-first selection outsid
         await page.locator('[data-interaction-id="input-1"]').isVisible(),
         true
     );
-    const applied = (await postedMessages(page)).at(-1);
-    assert.equal(applied.type, 'conversation-viewer-applied');
-    assert.equal(applied.requestId, 2);
+    const applied = (await postedMessages(page)).find(message =>
+        message.type === 'conversation-viewer-applied'
+        && message.requestId === 2
+        && message.htmlSignature === 'first-question-outside-outline'
+    );
+    assert.ok(applied, 'the correlated navigation publication is acknowledged');
+    assert.equal(applied.subscriptionGeneration, 2);
 });
 
 test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 acknowledges a hidden retained Viewer without waiting for animation frames', async t => {


### PR DESCRIPTION
## Summary

- Correlate the navigation test with its `conversation-viewer-applied` receipt instead of depending on the last Webview message.
- Keep validation bound to the request and HTML signature required by the protocol, so browser focus events cannot make the test flaky.

## Verification

- `npm run test-compile`
- The focused Conversation Viewer test, repeated 10 times
- `npm run test:browser:run` — 491 passing
- `git diff --check`

## Skill harvest

No skill change: this was a test assertion ordering issue, and the existing review/fix workflow already required correlating asynchronous protocol results.

## Owner approvals

```
approve 86e0ff94d45defb4315ed64972278a73c8da944e
```
