### PR TITLE
feat: open confirmed external file links from AI Conversation

### DIFF
--- a/docs/ai-conversation-local-file-links.md
+++ b/docs/ai-conversation-local-file-links.md
@@ -1,0 +1,14 @@
+# Local file links in AI Conversation
+
+- Markdown in the conversation's worktree continues to use the comment-enabled document reader.
+- Other trusted workspace files open with VS Code's registered editor, including image previews rather than a forced text editor.
+- Absolute paths outside trusted workspace roots require confirmation showing the exact canonical filename. Cancellation does not open or read the file contents. Each external opening asks again; no directory permission or permanent grant is stored.
+- Confirmed external Markdown opens in an isolated read-only rendered panel, not an AI conversation or comment store. It supports Markdown and up to 20 Mermaid diagrams. Unsupported execution/copy/sort controls are absent. External resources are blocked by CSP; linked files require their own confirmation.
+- Relative paths cannot escape their authoritative workspace. Missing, inaccessible, non-regular, changed or oversized files produce a visible warning and a diagnostic entry.
+- Line and column references are retained by an explicit editable-source button in external Markdown previews; opening the source requires confirmation again.
+
+## Boundaries
+
+External Markdown is limited to 2 MiB and 8 MiB of rendered HTML. Reads use a bounded buffer and check the opened file's identity and metadata before displaying its contents. Closing a read-only preview cancels pending linked-file displays from it.
+
+Native VS Code editors take a canonical pathname, not an already-open file descriptor. Consent authorizes that pathname; another process replacing the file after validation and before VS Code resolves it cannot be prevented by this extension. This feature does not claim immutable object identity for native editors. It does not execute linked programs or send external content to AI.

--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1670,15 +1670,17 @@
   {
     "id": "CONVERSATION-LOCAL-FILE-LINKS-001",
     "domain": "webview",
-    "title": "AI Conversation renders absolute local file references as clickable links and opens their exact line in the workspace host",
+    "title": "AI Conversation opens trusted local links and explicitly confirmed external files, with native image viewing and isolated read-only Markdown",
     "priority": "P1",
     "status": "automated",
     "owners": [
       "tests/integration/dashboard/conversationViewer.test.js",
+      "tests/contract/dashboardBoundaries.test.js",
       "tests/browser/conversationViewer.test.js"
     ],
     "evidence": [
       "src/dashboard.ts",
+      "src/dashboard/markdownReviewCommand.ts",
       "src/aiSessions/conversation/composition.ts",
       "src/aiSessions/conversation/markdown.ts",
       "src/aiSessions/conversation/viewer.ts",

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -261,7 +261,8 @@ import { getDashboardBootContent } from './dashboard/bootContent';
 import { getAgentPivotConfiguration } from './configuration';
 import { DashboardCommandRegistration } from './dashboard/commandRegistration';
 import { ActiveTerminalFileReferenceController } from './dashboard/activeTerminalFileReference';
-import { isSameMarkdownReviewWorktree, MarkdownReviewCandidate, MarkdownReviewCommandController } from './dashboard/markdownReviewCommand';
+import { isSameMarkdownReviewWorktree, MarkdownReviewCandidate, MarkdownReviewCommandController, LocalFileReviewController, buildReadOnlyMarkdownPreview } from './dashboard/markdownReviewCommand';
+import { parseConversationLocalFileLink, parseConversationWorkspaceFileLink } from './aiSessions/conversation/markdown';
 import DashboardDiagnostics from './dashboard/diagnostics';
 import { getErrorContent } from './dashboard/errorContent';
 import { GroupCollapseController } from './dashboard/groupCollapseController';
@@ -1775,6 +1776,7 @@ async function initializeDashboard(
         handle => clearTimeout(handle),
     );
     let conversationCapability: ConversationCapability;
+    let localFileOpenGeneration = 0;
     const aiSessionDashboardController = ownResource(() => new AiSessionDashboardController<
         AiSessionPresentationTransaction<vscode.Terminal>
     >({
@@ -2123,6 +2125,9 @@ async function initializeDashboard(
             } : undefined;
         },
         openLocalFile: async (targetFile, viewerTarget) => {
+            const generation = ++localFileOpenGeneration;
+            const navigation = conversationNavigationIntent;
+            const current = () => generation === localFileOpenGeneration && navigation === conversationNavigationIntent;
             const actionTarget = getCurrentWorkspaceActionTarget(
                 viewerTarget.projectId
             );
@@ -2154,40 +2159,58 @@ async function initializeDashboard(
             const roots = 'relativePath' in targetFile && authoritativeRoots.length > 0
                 ? authoritativeRoots
                 : [...authoritativeRoots, ...workspaceRoots];
-            for (const rootPath of roots) {
-                let canonicalRoot: string;
-                try {
-                    canonicalRoot = await realpathPath(rootPath);
-                } catch (_error) {
-                    continue;
-                }
-                const candidate = 'relativePath' in targetFile
-                    ? path.resolve(canonicalRoot, targetFile.relativePath)
-                    : path.resolve(targetFile.fsPath);
-                // Resolve both ends before containment testing. This rejects a
-                // model-supplied traversal and a seemingly local symlink that
-                // leaves an opened workspace root.
-                let canonicalCandidate: string;
-                try {
-                    canonicalCandidate = await realpathPath(candidate);
-                } catch (_error) {
-                    continue;
-                }
-                if (!isWorkspaceHostPathContained(
-                    canonicalRoot,
-                    canonicalCandidate
-                )) {
-                    continue;
-                }
-                const position = new vscode.Position(
-                    targetFile.line - 1,
-                    targetFile.column - 1
-                );
-                await vscode.window.showTextDocument(
-                    vscode.Uri.file(canonicalCandidate),
-                    { selection: new vscode.Range(position, position) }
-                );
+            const controller = new LocalFileReviewController({
+                confirm: async (file, editable) => await vscode.window.showWarningMessage(
+                    `Open this file outside the workspace?\n${file}\nOnly this file will be opened. Its contents are not sent to AI. ${editable ? 'The source editor may allow changes to this file.' : 'Markdown previews are read-only.'}`,
+                    { modal: true }, 'Open file'
+                ) === 'Open file',
+                inform: message => vscode.window.showWarningMessage(message),
+                log: error => logError('Could not open Conversation file link', error),
+                openNative: async (file, line, column) => {
+                    const position = new vscode.Position(line - 1, column - 1);
+                    await vscode.commands.executeCommand('vscode.open', vscode.Uri.file(file), {
+                        preview: true, selection: new vscode.Range(position, position),
+                    });
+                },
+                preview: async (file, markdown, line, column) => {
+                    const panel = vscode.window.createWebviewPanel('agentPivot.readOnlyDocument',
+                        `${path.basename(file)} (read-only)`, vscode.ViewColumn.Beside,
+                        { enableScripts: true, localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'media')] });
+                    context.subscriptions.push(panel);
+                    const asset = (name: string) => panel.webview.asWebviewUri(vscode.Uri.joinPath(context.extensionUri, 'media', name)).toString();
+                    panel.webview.html = buildReadOnlyMarkdownPreview(file, markdown, {
+                        nonce: randomBytes(18).toString('hex'), csp: panel.webview.cspSource,
+                        css: asset('conversationViewer.css'), katex: asset('katex.min.css'), purify: asset('purify.min.js'), mermaidRuntime: asset('conversationMermaidScripts.js'), mermaid: asset('mermaid.min.js'),
+                    }, line, column);
+                    let alive = true;
+                    panel.onDidDispose(() => { alive = false; });
+                    panel.webview.onDidReceiveMessage(async message => {
+                        if (alive && message?.type === 'open-source') {
+                            await controller.open({ fsPath: file, line, column }, [], () => alive, true, true);
+                            return;
+                        }
+                        if (!alive || message?.type !== 'open-link' || typeof message.href !== 'string' || message.href.length > 8192) { return; }
+                        const local = parseConversationLocalFileLink(message.href);
+                        const relative = parseConversationWorkspaceFileLink(message.href);
+                        if (local || relative) {
+                            await controller.open(local || { fsPath: path.resolve(path.dirname(file), relative!.relativePath),
+                                line: relative!.line, column: relative!.column }, [], () => alive);
+                        } else if (/^https:\/\//i.test(message.href)) {
+                            await vscode.env.openExternal(vscode.Uri.parse(message.href));
+                        } else {
+                            void vscode.window.showWarningMessage('This link cannot be opened from the read-only preview.');
+                        }
+                    });
+                },
+            });
+            if ('relativePath' in targetFile && !roots.length) {
+                void vscode.window.showWarningMessage('The file’s workspace is no longer available.');
                 return;
+            }
+            if ('relativePath' in targetFile) {
+                await controller.openRelative(targetFile, roots, current);
+            } else {
+                await controller.open(targetFile, roots, current);
             }
         },
         readWorkspaceMarkdown: async (targetFile, viewerTarget) => {

--- a/src/dashboard/markdownReviewCommand.ts
+++ b/src/dashboard/markdownReviewCommand.ts
@@ -1,8 +1,118 @@
 'use strict';
 
 import * as path from 'path';
+import * as fs from 'fs/promises';
+import { constants } from 'fs';
+import { renderConversationMarkdown } from '../aiSessions/conversation/markdown';
 import type { ConversationSessionOpenTarget, MarkdownReviewOpenResult } from '../aiSessions/conversation/composition';
 import type { ConversationWorkspaceFileTarget } from '../aiSessions/conversation/markdown';
+
+interface LocalFileReviewOptions {
+    confirm(file: string, editable: boolean): Promise<boolean>;
+    preview(file: string, markdown: string, line: number, column: number): Promise<void>;
+    openNative(file: string, line: number, column: number): Promise<void>;
+    inform(message: string): unknown;
+    log(error: unknown): void;
+}
+
+/** Consent is scoped to one canonical pathname, never its directory.
+ * Native editors own subsequent pathname resolution; Markdown uses a checked file handle. */
+export class LocalFileReviewController {
+    constructor(private readonly options: LocalFileReviewOptions) {}
+
+    async openRelative(target: { relativePath: string; line: number; column: number }, roots: string[], current: () => boolean): Promise<void> {
+        for (const root of roots) {
+            if (!current()) { return; }
+            try {
+                const canonicalRoot = await fs.realpath(root);
+                const file = await fs.realpath(path.resolve(canonicalRoot, target.relativePath));
+                const relative = path.relative(canonicalRoot, file);
+                if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) { continue; }
+                await this.open({ fsPath: file, line: target.line, column: target.column }, [canonicalRoot], current, false);
+                return;
+            } catch (_error) { /* Try the next compatibility root, without granting external access. */ }
+        }
+        if (current()) { this.options.inform('The linked file could not be found inside its workspace.'); }
+    }
+
+    async open(target: { fsPath: string; line: number; column: number }, roots: string[], current: () => boolean, allowExternal = true, nativeOnly = false): Promise<void> {
+        try {
+            const file = await fs.realpath(target.fsPath);
+            const initial = await fs.stat(file);
+            if (!initial.isFile()) { throw new Error('Not a regular file'); }
+            let trusted = false;
+            for (const root of roots) {
+                try {
+                    const relative = path.relative(await fs.realpath(root), file);
+                    if (relative && relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)) { trusted = true; }
+                } catch (_error) { /* A removed workspace root grants no access. */ }
+            }
+            if (!current()) { return; }
+            if (!trusted && !allowExternal) { throw new Error('Relative link leaves its workspace'); }
+            if (!trusted && !await this.options.confirm(file, nativeOnly)) { return; }
+            if (!current()) { return; }
+            const latest = await fs.stat(file);
+            if (await fs.realpath(target.fsPath) !== file || !latest.isFile()
+                || latest.dev !== initial.dev || latest.ino !== initial.ino || latest.mtimeMs !== initial.mtimeMs || latest.size !== initial.size) {
+                throw new Error('File changed while confirming access');
+            }
+            if (!trusted && !nativeOnly && file.toLowerCase().endsWith('.md')) {
+                if (latest.size > 2 * 1024 * 1024) { throw new Error('Markdown file exceeds 2 MiB'); }
+                const handle = await fs.open(file, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+                let markdown: string;
+                try {
+                    const before = await handle.stat();
+                    if (!before.isFile() || before.dev !== latest.dev || before.ino !== latest.ino
+                        || await fs.realpath(file) !== file) { throw new Error('File changed before reading'); }
+                    const buffer = Buffer.alloc(2 * 1024 * 1024 + 1);
+                    let total = 0;
+                    while (total < buffer.length) {
+                        const read = await handle.read(buffer, total, buffer.length - total, total);
+                        if (!read.bytesRead) { break; }
+                        total += read.bytesRead;
+                    }
+                    const after = await handle.stat();
+                    if (total > 2 * 1024 * 1024 || before.mtimeMs !== after.mtimeMs || before.size !== after.size
+                        || before.mtimeMs !== latest.mtimeMs || before.size !== latest.size) { throw new Error('File changed or exceeds 2 MiB'); }
+                    markdown = buffer.subarray(0, total).toString('utf8');
+                } finally { await handle.close(); }
+                if (current()) { await this.options.preview(file, markdown, target.line, target.column); }
+            } else if (current()) {
+                await this.options.openNative(file, target.line, target.column);
+            }
+        } catch (error) {
+            this.options.log(error);
+            if (current()) { this.options.inform('The linked file could not be opened. It may be missing, inaccessible, changed, or too large. See Agent Pivot output for details.'); }
+        }
+    }
+}
+
+/** Isolated rendered preview: no comment store, AI dispatch, or write messages. */
+export function buildReadOnlyMarkdownPreview(file: string, markdown: string, assets: {
+    nonce: string; csp: string; css: string; katex: string; purify: string; mermaidRuntime: string; mermaid: string;
+}, line = 1, column = 1): string {
+    const escape = (value: string) => value.replace(/[&<>"']/g, character => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[character]!));
+    const html = renderConversationMarkdown(markdown);
+    if (Buffer.byteLength(html, 'utf8') > 8 * 1024 * 1024) { throw new Error('Rendered Markdown exceeds 8 MiB'); }
+    return `<!doctype html><html><head><meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${escape(assets.csp)} 'unsafe-inline'; script-src 'nonce-${escape(assets.nonce)}'; img-src data: blob:; font-src ${escape(assets.csp)};">
+<link rel="stylesheet" href="${escape(assets.css)}">
+<link rel="stylesheet" href="${escape(assets.katex)}">
+<style nonce="${escape(assets.nonce)}">body{display:block;overflow:auto;padding:16px;font-family:var(--vscode-font-family,sans-serif);line-height:1.6}header{margin-bottom:16px;overflow-wrap:anywhere}main{max-width:58rem;margin:auto}.conversation-markdown{overflow-wrap:anywhere}</style>
+</head><body data-mermaid-source="${escape(assets.mermaid)}"><header><strong>${escape(path.basename(file))}</strong><div>Read-only · Outside workspace</div><details><summary>File location</summary>${escape(file)}</details><button type="button" data-open-source>Open editable source at line ${line}, column ${column}</button></header>
+<main class="conversation-markdown">${html}</main>
+<script nonce="${escape(assets.nonce)}">window.__agentPivotConversation={};</script>
+<script nonce="${escape(assets.nonce)}" src="${escape(assets.purify)}"></script>
+<script nonce="${escape(assets.nonce)}" src="${escape(assets.mermaidRuntime)}"></script>
+<script nonce="${escape(assets.nonce)}">(function(){
+var api=acquireVsCodeApi();
+document.querySelectorAll('main button').forEach(function(button){button.remove();});
+document.querySelector('[data-open-source]').addEventListener('click',function(){api.postMessage({type:'open-source'});});
+document.addEventListener('click',function(e){var a=e.target.closest('a');if(a){e.preventDefault();api.postMessage({type:'open-link',href:a.getAttribute('href')});}});
+var renderer=window.__agentPivotConversation.mermaid.create({messages:document.querySelector('main'),scroll:document.scrollingElement,source:document.body.dataset.mermaidSource,nonce:document.currentScript.nonce,maxDiagrams:20,captureAnchor:function(){return null;},restoreAnchor:function(){}});
+renderer.render();
+})();</script></body></html>`;
+}
 
 /** Canonical paths must share a root without crossing a nested repository. */
 export async function isSameMarkdownReviewWorktree(

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -8,6 +8,42 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const { chromium } = require('playwright-chromium');
+
+test('CONVERSATION-LOCAL-FILE-LINKS-001 external Markdown is rendered without comment or AI controls', async t => {
+    const { buildReadOnlyMarkdownPreview } = require('../../out/dashboard/markdownReviewCommand');
+    const browser = await chromium.launch({ headless: true });
+    t.after(() => browser.close());
+    const page = await browser.newPage({ viewport: { width: 360, height: 700 } });
+    const errors = [];
+    page.on('pageerror', error => errors.push(error.message));
+    page.on('console', message => { if (message.type() === 'error') errors.push(message.text()); });
+    await page.addInitScript(() => { window.acquireVsCodeApi = () => ({ postMessage: message => { window.lastLink = message; } }); });
+    const assets = { nonce: 'testnonce', csp: 'https://preview.test', css: 'https://preview.test/conversationViewer.css',
+        katex: 'https://preview.test/katex.min.css', purify: 'https://preview.test/purify.js', mermaidRuntime: 'https://preview.test/runtime.js', mermaid: 'https://preview.test/mermaid.js' };
+    await page.route('https://preview.test/**', route => {
+        const url = route.request().url();
+        const body = url.endsWith('katex.min.css') ? fs.readFileSync(path.join(__dirname, '../../media/katex.min.css'), 'utf8')
+            : url.endsWith('purify.js') ? purifyScript : url.endsWith('runtime.js') ? conversationMermaidScript : url.endsWith('mermaid.js') ? mermaidScript
+            : url.endsWith('.css') ? fs.readFileSync(path.join(__dirname, '../../media/conversationViewer.css'), 'utf8')
+                : buildReadOnlyMarkdownPreview('/tmp/report.md', '# Report\n\n**Read only**\n\n$x^2$\n\n[Image](/tmp/image.png)\n\n```sh\necho hello\n```\n\n```diff\n--- a/demo.txt\n+++ b/demo.txt\n@@ -1 +1 @@\n-old\n+new\n```\n\n```mermaid\ngraph TD\nA-->B\n```', assets);
+        return route.fulfill({ body, contentType: url.endsWith('.js') ? 'application/javascript' : url.endsWith('.css') ? 'text/css' : 'text/html' });
+    });
+    await page.goto('https://preview.test/');
+    assert.equal(await page.locator('h1').innerText(), 'Report');
+    assert.equal(await page.locator('textarea, [data-markdown-workspace-comment-composer], [data-markdown-workspace-comment-send]').count(), 0);
+    assert.match(await page.locator('header').innerText(), /Read-only.*Outside workspace/);
+    assert.match(await page.locator('.katex').evaluate(el => getComputedStyle(el).fontFamily), /KaTeX/);
+    assert.equal(await page.locator('main button').count(), 0, 'no inert or executable controls in a read-only preview');
+    assert.match(await page.locator('main').innerText(), /old/);
+    assert.match(await page.locator('main').innerText(), /new/);
+    try { await page.locator('.conversation-mermaid-image').waitFor({ state: 'visible', timeout: 5000 }); }
+    catch (error) { assert.fail(errors.join('\n') + '\n' + await page.locator('main').innerText()); }
+    await page.getByRole('link', { name: 'Image', exact: true }).click();
+    assert.equal((await page.evaluate(() => window.lastLink)).type, 'open-link');
+    await page.locator('[data-open-source]').click();
+    assert.equal((await page.evaluate(() => window.lastLink)).type, 'open-source');
+    await page.screenshot({ path: '/tmp/external-markdown-readonly.png' });
+});
 const {
     ConversationCommentFileStore,
 } = require('../../out/aiSessions/conversation/commentStore');

--- a/tests/contract/dashboardBoundaries.test.js
+++ b/tests/contract/dashboardBoundaries.test.js
@@ -471,6 +471,47 @@ function markdownReviewFixture(overrides = {}) {
     return { controller: new MarkdownReviewCommandController(options), options, candidate, document, opened, notices };
 }
 
+test('CONVERSATION-LOCAL-FILE-LINKS-001 confirms exact external files and routes Markdown read-only', async () => {
+    const { LocalFileReviewController } = require('../../out/dashboard/markdownReviewCommand');
+    assert.equal(typeof LocalFileReviewController, 'function', 'local file review must expose a guarded opening controller');
+    const os = require('node:os');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conversation-link-'));
+    const file = path.join(dir, 'report.md');
+    fs.writeFileSync(file, '# Report');
+    const prompts = [], previews = [], notices = [], native = [];
+    const options = { confirm: async name => { prompts.push(name); return false; },
+        preview: async (name, text, line, column) => previews.push([name, text, line, column]),
+        openNative: async name => native.push(name), inform: text => notices.push(text), log: () => {} };
+    const controller = new LocalFileReviewController(options);
+    try {
+        await controller.open({ fsPath: file, line: 1, column: 1 }, [], () => true);
+        assert.deepEqual(previews, []);
+        assert.deepEqual(prompts, [file]);
+        options.confirm = async () => true;
+        await controller.open({ fsPath: file, line: 120, column: 4 }, [], () => true);
+        assert.deepEqual(previews, [[file, '# Report', 120, 4]]);
+        assert.deepEqual(native, []);
+        const image = path.join(dir, 'image.png');
+        fs.writeFileSync(image, 'fixture');
+        await controller.open({ fsPath: image, line: 1, column: 1 }, [dir], () => true);
+        assert.deepEqual(native, [image]);
+        const firstRoot = path.join(dir, 'first');
+        fs.mkdirSync(firstRoot);
+        await controller.openRelative({ relativePath: 'image.png', line: 1, column: 1 }, [firstRoot, dir], () => true);
+        assert.deepEqual(native, [image, image], 'relative compatibility links search subsequent workspace roots');
+        await controller.openRelative({ relativePath: '../image.png', line: 1, column: 1 }, [firstRoot], () => true);
+        assert.equal(native.length, 2, 'an authoritative root must not fall through or permit traversal');
+        options.confirm = async () => { fs.writeFileSync(file, '# Changed report'); return true; };
+        await controller.open({ fsPath: file, line: 1, column: 1 }, [], () => true);
+        assert.equal(previews.length, 1, 'changing a file during approval cannot reuse consent');
+        options.confirm = async () => { assert.fail('relative escapes must not request broader permission'); };
+        await controller.open({ fsPath: file, line: 1, column: 1 }, [], () => true, false);
+        assert.equal(previews.length, 1);
+        await controller.open({ fsPath: path.join(dir, 'missing.md'), line: 1, column: 1 }, [], () => true);
+        assert.match(notices.at(-1), /could not be opened/i);
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
 test('CONVERSATION-MARKDOWN-WORKSPACE-001 review reports the failed stage but not superseded navigation', async () => {
     for (const [result, message] of [['cancelled', undefined], ['document-unavailable', /document could not be opened/i],
         ['conversation-unavailable', /conversation could not be opened/i]]) {
@@ -874,6 +915,12 @@ test('CONVERSATION-ACTIVE-SESSION-NAVIGATION-COMMANDS-001 marks only an actually
         source,
         /sessionId: selected\.sessionId,\s*}, true\);/
     );
+});
+
+test('CONVERSATION-LOCAL-FILE-LINKS-001 external preview opens after production bootstrap transfers resources', () => {
+    const result = spawnSync(process.execPath, [path.resolve(__dirname, '../fixtures/aiSessions/runtimeHostActivationHarness.js'), 'local-file-review'],
+        { encoding: 'utf8', env: process.env });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
 });
 
 test('WEBVIEW-DASHBOARD-COMMAND-REGISTRATION-001 production activation installs the exact Dashboard public command surface', () => {

--- a/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
+++ b/tests/fixtures/aiSessions/runtimeHostActivationHarness.js
@@ -335,11 +335,18 @@ async function main() {
     const compositionSectionsPath = path.join(root, 'out', 'dashboard', 'sections');
     const isCompositionSource = filename => filename === dashboardPath
         || (filename && filename.startsWith(compositionSectionsPath + path.sep));
+    let capturedConversationOptions;
     Module._load = function (request, parent, isMain) {
         if (request === 'vscode') return vscode;
         const isCompositionRequest = moduleName => isCompositionSource(parent?.filename)
             && request.endsWith(`/${moduleName}`);
         const loaded = previousLoad.call(this, request, parent, isMain);
+        if (mode === 'local-file-review' && isCompositionRequest('aiSessions/conversation/composition')) {
+            return { ...loaded, createConversationCapability: options => {
+                capturedConversationOptions = options;
+                return loaded.createConversationCapability(options);
+            } };
+        }
         if (isCompositionRequest('workspaces/sessionHydrationController')) {
             const Original = loaded.WorkspaceSessionHydrationController;
             return {
@@ -652,6 +659,42 @@ async function main() {
             await waitFor(() => tmuxRestoreSettled, 'tmux restoration to settle');
         }
         await activationFlight;
+        if (mode === 'local-file-review') {
+            await waitFor(() => vscode.registeredProvider?.lifecycle?.kind === 'ready', 'bootstrap ready before external link');
+            const file = path.join(storageRoot, 'external-report.md');
+            fs.writeFileSync(file, '# External report');
+            let panel;
+            let onPreviewMessage;
+            const nativeOpens = [];
+            vscode.Position = class { constructor(line, character) { this.line = line; this.character = character; } };
+            vscode.Range = class { constructor(start, end) { this.start = start; this.end = end; } };
+            const execute = vscode.commands.executeCommand;
+            vscode.commands.executeCommand = async (command, ...args) => {
+                if (command === 'vscode.open') { nativeOpens.push(args); return; }
+                return execute(command, ...args);
+            };
+            vscode.window.showWarningMessage = async () => 'Open file';
+            vscode.window.createWebviewPanel = () => {
+                panel = { dispose() {}, onDidDispose: () => disposable(), webview: {
+                    html: '', cspSource: 'fixture-webview', asWebviewUri: value => value,
+                    onDidReceiveMessage: handler => { onPreviewMessage = handler; return disposable(); },
+                } };
+                return panel;
+            };
+            await capturedConversationOptions.openLocalFile({ fsPath: file, line: 12, column: 4 },
+                { projectId: 'external-link-project', provider: 'codex', sessionId: 'external-link-session' });
+            assert.ok(panel?.webview.html.includes('External report'), 'post-bootstrap link must publish a rendered preview');
+            assert.ok(panel.webview.html.includes('line 12, column 4'), 'source position is preserved');
+            await onPreviewMessage({ type: 'open-source' });
+            assert.equal(nativeOpens[0][0].fsPath, file);
+            assert.equal(nativeOpens[0][1].selection.start.line, 11);
+            assert.equal(nativeOpens[0][1].selection.start.character, 3);
+            const image = path.join(storageRoot, 'preview.png');
+            fs.writeFileSync(image, 'fixture');
+            await capturedConversationOptions.openLocalFile({ fsPath: image, line: 1, column: 1 },
+                { projectId: 'external-link-project', provider: 'codex', sessionId: 'external-link-session' });
+            assert.equal(nativeOpens.at(-1)[0].fsPath, image, 'images use vscode.open rather than showTextDocument');
+        }
         if (mode === 'slow-runtime-restore' || mode === 'blocked-restore-budget') {
             await waitFor(
                 () => pendingInactiveRestoreEntered && pendingDirectRestoreEntered,


### PR DESCRIPTION
## Summary

- Open local screenshot/report links from AI Conversation instead of silently rejecting files outside the workspace.
- Keep worktree Markdown in the existing comment-enabled reader; route images and other trusted files to VS Code's registered editor.
- Require exact-path confirmation for external files. Render external Markdown in an isolated read-only panel with Mermaid and KaTeX, bounded reads, no AI/comment writes, and an explicitly confirmed editable-source escape hatch preserving line/column.
- Preserve authoritative-root isolation and ordered multi-root compatibility fallback. Surface missing/changed/inaccessible files as warnings.

## Verification

- Fresh `npm run test-compile` and six focused local-file-link checks passed, including production post-bootstrap panel creation, native image/source routing, confirmation/cancellation, multi-root fallback and browser rendering.
- `npm run test:ci:linux` exited 0; browser, Dashboard, architecture, coverage and release-packaging checks completed. Changed-line coverage: 100% (110/110).
- Known local harness limitation: the AI-session safety script exits 0 before its success banner on this machine (also reproduced on the clean base). This is not claimed as a complete safety-script pass; hosted CI remains authoritative for that lane.
- Final read-only integration review: no Critical/Important findings. `git diff --check` passed.
- Built Agent Pivot 1.4.3 and Attention UI Bridge 1.4.1 VSIX files; neither installed by this change. The bridge runtime is unchanged.

## Boundaries

- Every external opening requires confirmation; no directory or permanent grants are stored.
- Native VS Code editors resolve a pathname, so immutable file identity after dispatch cannot be guaranteed. External Markdown uses identity-checked bounded file-handle reads.
- External Markdown does not enable comments or send content to AI. See `docs/ai-conversation-local-file-links.md`.

## Skill harvest

No skill change justified: post-bootstrap lifecycle and inert read-only controls were caught by the existing regression-test and final-review workflow; those skills already require production-path checks and fresh verification after fixes. Added executable regressions rather than duplicating guidance.

## Owner approvals

This new PR is not covered by approval of the previously merged PR #440. To authorize this exact head, post:

```text
approve dd9868d88aa96714eab5ec91dc17e4a5075153af
```
