### PR TITLE
Fix relative links and SVG images in Markdown review

### DIFF
--- a/docs/testing/behavior-contracts.json
+++ b/docs/testing/behavior-contracts.json
@@ -1,5 +1,22 @@
 [
   {
+    "id": "CONVERSATION-MARKDOWN-RESOURCES-001",
+    "domain": "webview",
+    "title": "Markdown review resolves document-relative links and loads workspace SVG images",
+    "priority": "P1",
+    "status": "automated",
+    "owners": [
+      "tests/unit/aiSessions/conversationMarkdown.test.js",
+      "tests/integration/dashboard/conversationViewer.test.js",
+      "tests/browser/conversationViewer.test.js"
+    ],
+    "evidence": [
+      "src/aiSessions/conversation/markdown.ts",
+      "src/aiSessions/conversation/viewer.ts",
+      "src/dashboard.ts"
+    ]
+  },
+  {
     "id": "ACTIVE-SESSION-CONVERSATION-OPEN-001",
     "domain": "webview",
     "title": "Clicking a focused Active Session opens its AI Conversation at the latest user input",

--- a/src/aiSessions/conversation/markdown.ts
+++ b/src/aiSessions/conversation/markdown.ts
@@ -3,6 +3,7 @@
 import MarkdownIt = require('markdown-it');
 import { randomBytes } from 'crypto';
 import { URL } from 'url';
+import { posix } from 'path';
 import { parseUnifiedDiff } from './diffs';
 import { renderConversationDiffs } from './diffRenderer';
 import { CONVERSATION_RUN_COMMAND_MAX_TEXT_LENGTH } from './viewerProtocol';
@@ -649,10 +650,61 @@ markdown.validateLink = (url: string): boolean => {
         || parseConversationWorkspaceFileLink(url));
 };
 
-export function renderConversationMarkdown(value: string): string {
+export interface ConversationMarkdownDocumentOptions {
+    documentPath: string;
+    resolveImage?: (relativePath: string) => string | undefined;
+}
+
+/** Resolve inside the authoritative workspace, relative to the document. */
+export function resolveMarkdownDocumentResource(value: string, documentPath: string): string | undefined {
+    let decoded: string;
+    try { decoded = decodeURIComponent(value); } catch (_error) { return undefined; }
+    if (!decoded || /^(?:[a-z][a-z0-9+.-]*:|[\\/])/i.test(decoded)
+        || /[\u0000-\u001f\u007f?]/.test(decoded)) { return undefined; }
+    const resolved = posix.normalize(posix.join(posix.dirname(documentPath), decoded.replace(/\\/g, '/')));
+    return parseConversationWorkspaceFileLink(resolved) ? resolved : undefined;
+}
+
+// Share the syntax extensions, but keep document-relative validation separate
+// from transcript links, which have no document directory as their base.
+const documentMarkdown: MarkdownIt = Object.create(markdown);
+documentMarkdown.validateLink = (url: string): boolean => markdown.validateLink(url)
+    || !!resolveMarkdownDocumentResource(url, 'document.md')
+    || !!parseConversationWorkspaceFileLink(url.replace(/^(?:\.\.?\/)+/, ''));
+const defaultImageRenderer = markdown.renderer.rules.image!;
+markdown.renderer.rules.image = (tokens, index, options, env, renderer) => {
+    const context = env as ConversationMarkdownDocumentOptions | undefined;
+    if (context?.documentPath) {
+        const token = tokens[index];
+        const source = token.attrGet('src') || '';
+        if (!/^https:\/\//i.test(source)) {
+            const relative = resolveMarkdownDocumentResource(source, context.documentPath);
+            const resource = relative && context.resolveImage?.(relative);
+            if (!resource) { return escapeHtml(token.content); }
+            token.attrSet('src', resource);
+        }
+    }
+    return defaultImageRenderer(tokens, index, options, env, renderer);
+};
+markdown.renderer.rules.link_open = (tokens, index, options, env, renderer) => {
+    const context = env as ConversationMarkdownDocumentOptions | undefined;
+    if (context?.documentPath) {
+        const token = tokens[index];
+        const href = token.attrGet('href') || '';
+        const relative = resolveMarkdownDocumentResource(href, context.documentPath);
+        if (relative) { token.attrSet('href', relative); }
+        else if (!markdown.validateLink(href)) {
+            token.attrs = (token.attrs || []).filter(attribute => attribute[0] !== 'href');
+        }
+    }
+    return renderer.renderToken(tokens, index, options);
+};
+
+export function renderConversationMarkdown(value: string, document?: ConversationMarkdownDocumentOptions): string {
     renderedMathExpressions = 0;
     renderedMathLength = 0;
-    return renderAdmonitions(renderTaskLists(renderSortableTables(markdown.render(value))));
+    return renderAdmonitions(renderTaskLists(renderSortableTables(
+        (document ? documentMarkdown : markdown).render(value, document))));
 }
 
 function renderSortableTables(html: string): string {

--- a/src/aiSessions/conversation/viewer.ts
+++ b/src/aiSessions/conversation/viewer.ts
@@ -181,9 +181,9 @@ export interface ConversationViewerOptions {
     readWorkspaceMarkdown?: (
         target: ConversationWorkspaceFileTarget,
         viewerTarget: ConversationViewerTarget
-    ) => PromiseLike<{ markdown: string; workspaceRootId: string; documentVersion: string } | undefined>
-        | Promise<{ markdown: string; workspaceRootId: string; documentVersion: string } | undefined>
-        | { markdown: string; workspaceRootId: string; documentVersion: string } | undefined;
+    ) => PromiseLike<{ markdown: string; workspaceRootId: string; documentVersion: string; resourceRootUri?: string } | undefined>
+        | Promise<{ markdown: string; workspaceRootId: string; documentVersion: string; resourceRootUri?: string } | undefined>
+        | { markdown: string; workspaceRootId: string; documentVersion: string; resourceRootUri?: string } | undefined;
     applyWorkspaceMarkdownSuggestion?: (
         target: ConversationWorkspaceFileTarget,
         viewerTarget: ConversationViewerTarget,
@@ -2386,7 +2386,7 @@ export class ConversationViewer implements ConversationViewerApi {
         const panel = this.panel;
         const workspaceRequestId = ++this.nextMarkdownWorkspaceRequestId;
         if (!target || !panel || !isCurrent()) { return false; }
-        let document: { markdown: string; workspaceRootId: string; documentVersion: string } | undefined;
+        let document: { markdown: string; workspaceRootId: string; documentVersion: string; resourceRootUri?: string } | undefined;
         try {
             document = await this.options.readWorkspaceMarkdown?.(
                 workspaceFile,
@@ -2416,7 +2416,19 @@ export class ConversationViewer implements ConversationViewerApi {
         }
         const title = workspaceFile.relativePath.split('/').pop()
             || workspaceFile.relativePath;
-        const html = renderConversationMarkdown(document.markdown);
+        const resourceRoot = document.resourceRootUri ? vscode.Uri.parse(document.resourceRootUri) : undefined;
+        panel.webview.options = {
+            ...panel.webview.options,
+            localResourceRoots: [this.options.mediaUri(''), ...(resourceRoot ? [resourceRoot] : [])],
+        };
+        const html = renderConversationMarkdown(document.markdown, {
+            documentPath: workspaceFile.relativePath,
+            resolveImage: relative => resourceRoot
+                ? panel.webview.asWebviewUri(vscode.Uri.parse(
+                    resourceRoot.toString().replace(/\/$/, '') + '/'
+                    + relative.split('/').map(encodeURIComponent).join('/')
+                )).toString() : undefined,
+        });
         if (Buffer.byteLength(html, 'utf8') > 8 * 1024 * 1024) {
             this.showNotice('Markdown document is too large to display.');
             return false;

--- a/src/aiSessions/conversation/viewerDocument.ts
+++ b/src/aiSessions/conversation/viewerDocument.ts
@@ -145,7 +145,7 @@ export function renderConversationViewerDocument(
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="Content-Security-Policy"
-        content="default-src 'none'; img-src https: blob:; font-src ${escapeAttribute(
+        content="default-src 'none'; img-src ${escapeAttribute(panel.webview.cspSource)} https: blob:; font-src ${escapeAttribute(
             panel.webview.cspSource
         )}; style-src ${escapeAttribute(
             panel.webview.cspSource

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2301,6 +2301,7 @@ async function initializeDashboard(
                 return {
                     markdown: new TextDecoder('utf-8', { fatal: true })
                         .decode(contents),
+                    resourceRootUri: vscode.Uri.file(canonicalRoot).toString(),
                     workspaceRootId: createHash('sha256')
                         .update(canonicalRoot).digest('hex'),
                     documentVersion: createHash('sha256')

--- a/tests/browser/conversationViewer.test.js
+++ b/tests/browser/conversationViewer.test.js
@@ -22187,3 +22187,35 @@ test('CONVERSATION-LARGE-SESSION-PERFORMANCE-001 resyncs when a tail patch misse
         '.conversation-deferred-messages').count(), 0,
         'the stray placeholder never lands');
 });
+
+test('CONVERSATION-MARKDOWN-RESOURCES-001 displays an SVG and activates a sibling Markdown link', async t => {
+    const { renderConversationMarkdown } = require('../../out/aiSessions/conversation/markdown');
+    const { page } = await openHostViewerDocument(t, { markdownWorkspaceOnly: true });
+    await page.addStyleTag({ content: viewerCss });
+    await page.setViewportSize({ width: 900, height: 750 });
+    await page.route('https://file.vscode-resource.vscode-cdn.net/**', route => route.fulfill({
+        contentType: 'image/svg+xml', body: '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="100"><rect width="320" height="100" fill="steelblue"/><text x="20" y="55" fill="white">Shared KV / CoorD / DN</text></svg>',
+    }));
+    const html = renderConversationMarkdown('## 系统保存什么\n\n![状态分为共享 KV、CoorD 内存和 DN 本地三层](./assets/01-state-layers.svg)\n\n详见 [状态、命名空间与 GC](./topics/01-state-and-kv.md)。', {
+        documentPath: 'docs/coord/report/02-coord-design-review.md',
+        resolveImage: resource => `https://file.vscode-resource.vscode-cdn.net/workspace/${resource}`,
+    });
+    await sendPage(page, {
+        type: 'conversation-viewer-markdown-workspace', version: 1,
+        href: 'docs/coord/report/02-coord-design-review.md', relativePath: 'docs/coord/report/02-coord-design-review.md',
+        workspaceRootId: 'root-a', documentVersion: 'v1', title: '02-coord-design-review.md', html,
+        workspaceRequestId: 1, subscriptionGeneration: 1, projectId: 'project-a', provider: 'codex', sessionId: 'session-host-document',
+        commentSnapshot: { revision: 0, comments: [] }, replies: [], suggestions: [],
+    });
+    const content = page.locator('[data-markdown-workspace-content]');
+    const image = content.getByRole('img');
+    await image.evaluate(img => img.decode());
+    assert.equal(await image.evaluate(img => img.naturalWidth), 320);
+    assert.equal(await image.isVisible(), true);
+    await content.getByRole('link', { name: '状态、命名空间与 GC' }).click();
+    assert.equal((await postedIntents(page)).at(-1).href, 'docs/coord/report/topics/01-state-and-kv.md');
+    await page.screenshot({ path: '/tmp/markdown-preview-resources.png' });
+    await page.setViewportSize({ width: 400, height: 750 });
+    assert.equal(await image.isVisible(), true);
+    await page.screenshot({ path: '/tmp/markdown-preview-resources-narrow.png' });
+});

--- a/tests/integration/dashboard/conversationViewer.test.js
+++ b/tests/integration/dashboard/conversationViewer.test.js
@@ -5296,7 +5296,7 @@ test('CONVERSATION-VIEWER-SECURITY-001 emits a nonce-only CSP and opens only HTT
     await viewer.open(target('session-a'));
 
     assert.match(panel.webview.html, /default-src 'none';/);
-    assert.match(panel.webview.html, /img-src https: blob:;/);
+    assert.match(panel.webview.html, /img-src fixture-csp https: blob:;/);
     assert.match(panel.webview.html, /style-src fixture-csp 'unsafe-inline';/);
     assert.match(panel.webview.html, /font-src fixture-csp;/);
     assert.match(panel.webview.html, /script-src 'nonce-[^']+';/);
@@ -10000,4 +10000,28 @@ test('WORKTREE-CHANGES-COMMITS-001 commits requests bind to generation and sessi
     assert.ok(!panel.postedMessages.slice(before).some(message =>
         message.type === 'conversation-viewer-commits'),
         'a pre-switch commits request never reaches the new session');
+});
+
+test('CONVERSATION-MARKDOWN-RESOURCES-001 publishes mapped images and document-relative navigation', async () => {
+    const opened = [];
+    const sources = [];
+    const { viewer, panel } = createViewer({
+        markdownWorkspaceOnly: true,
+        readWorkspaceMarkdown: async () => ({
+            markdown: '![状态](./assets/01-state-layers.svg)\n\n[状态、命名空间与 GC](./topics/01-state-and-kv.md)',
+            workspaceRootId: 'root', documentVersion: 'v1', resourceRootUri: 'file:///workspace',
+        }),
+        openLocalFile: async file => sources.push(file),
+        openMarkdownWorkspaceInPanel: async (_target, file) => opened.push(file.relativePath),
+    });
+    await viewer.openMarkdownWorkspaceDocument(target('session-a'), { relativePath: 'docs/coord/report/02-coord-design-review.md', line: 1, column: 1 });
+    const publication = panel.postedMessages.find(message => message.type === 'conversation-viewer-markdown-workspace');
+    assert.match(publication.html, /<img src="webview:\/\/fixture\/\/workspace\/docs\/coord\/report\/assets\/01-state-layers.svg"/);
+    assert.match(publication.html, /href="docs\/coord\/report\/topics\/01-state-and-kv.md"/);
+    assert.deepEqual(panel.webview.options.localResourceRoots.map(uri => uri.toString()), ['file:///extension/media/', 'file:///workspace']);
+    await panel.receive({ type: 'conversation-viewer-open-link', version: 1, href: 'docs/coord/report/topics/01-state-and-kv.md' });
+    assert.deepEqual(opened, ['docs/coord/report/topics/01-state-and-kv.md']);
+    await panel.receive({ type: 'conversation-viewer-open-link', version: 1, href: 'docs/coord/src/foo.ts:12:3' });
+    assert.deepEqual(sources, [{ relativePath: 'docs/coord/src/foo.ts', line: 12, column: 3 }]);
+    viewer.dispose();
 });

--- a/tests/unit/aiSessions/conversationMarkdown.test.js
+++ b/tests/unit/aiSessions/conversationMarkdown.test.js
@@ -328,3 +328,30 @@ test('CONVERSATION-LOCAL-FILE-LINKS-002 rejects traversal and unsafe workspace r
     assert.doesNotMatch(html, /href="\.\.\/private\.ts:1"/);
     assert.doesNotMatch(html, /href="src\/private\.ts\?token/);
 });
+
+test('CONVERSATION-MARKDOWN-RESOURCES-001 resolves document-relative links and SVG images', () => {
+    const html = renderConversationMarkdown('![状态分为共享 KV、CoorD 内存和 DN 本地三层](./assets/01-state-layers.svg)\n\n详见 [状态、命名空间与 GC](./topics/01-state-and-kv.md)。', {
+        documentPath: 'docs/review/02-coord-design-review.md',
+        resolveImage: resource => `https://file.vscode-resource.vscode-cdn.net/workspace/${resource}`,
+    });
+    assert.match(html, /<img src="https:\/\/file.vscode-resource.vscode-cdn.net\/workspace\/docs\/review\/assets\/01-state-layers.svg"/);
+    assert.match(html, /<a href="docs\/review\/topics\/01-state-and-kv.md">状态、命名空间与 GC<\/a>/);
+});
+
+test('CONVERSATION-MARKDOWN-RESOURCES-001 confines resources to the workspace and preserves transcript policy', () => {
+    const { resolveMarkdownDocumentResource } = require('../../../out/aiSessions/conversation/markdown');
+    assert.equal(resolveMarkdownDocumentResource('../assets/diagram.svg', 'docs/topics/review.md'), 'docs/assets/diagram.svg');
+    for (const href of ['../../../secret.svg', '%2e%2e/%2e%2e/secret.svg', 'javascript:alert(1)', 'file:///secret.svg', '//host/image.svg', 'data:image/svg+xml,foo']) {
+        assert.equal(resolveMarkdownDocumentResource(href, 'docs/review.md'), undefined, href);
+    }
+    const html = renderConversationMarkdown('[escape](../../secret.md) ![secret](../../secret.svg)', { documentPath: 'docs/review.md' });
+    assert.doesNotMatch(html, /(?:href|src)=/);
+    assert.doesNotMatch(renderConversationMarkdown('[relative](./docs/test.md)'), /href=/);
+    assert.match(renderConversationMarkdown('[site](https://example.com)', { documentPath: 'docs/review.md' }), /href="https:\/\/example.com"/);
+});
+
+test('CONVERSATION-MARKDOWN-RESOURCES-001 preserves source-link line and column positions', () => {
+    const html = renderConversationMarkdown('[source](../src/foo.ts:12:3) [line](../src/foo.ts#L18)', { documentPath: 'docs/review.md' });
+    assert.match(html, /href="src\/foo.ts:12:3"/);
+    assert.match(html, /href="src\/foo.ts#L18"/);
+});


### PR DESCRIPTION
Preview and Comment displayed relative Markdown image and link syntax as plain text, including `![diagram](./assets/diagram.svg)` and `[details](./topics/details.md)`.

Resolve document links relative to the Markdown file within its authoritative workspace, map local images through the Webview resource URI, and allow the Webview resource origin in the image CSP. Keep transcript link validation unchanged and preserve source-link line/column positions. Add rendered HTML, Host navigation, and browser SVG-loading regression tests.

## Validation
- Observed the original renderer fail on the reported relative image/link syntax before applying the fix.
- 191 Markdown/Viewer tests and 2 focused browser tests passed, including SVG loading, sibling document navigation, and rich document controls.
- Compile, behavior contracts, lint ratchet, and release packaging checks passed.
- Verified the production rendering at wide and narrow panel widths.
- Installed Agent Pivot 1.5.0 locally and in the reddev DevBox container; normalized manifests and runtime hashes match the VSIX. Window reload is required to activate the installed build.
- Read-only review found a source-link position regression; added a failing test, fixed it, and re-reviewed with no remaining Critical/Important findings.

## Skill harvest
No skill change: the installation skill already requires proving the target extension host. The initial ambiguity between SSH and Dev Container was a missed verification step; explicit Docker process and installed-byte checks resolved it.

## Owner approvals
After validation, the owner can post this exact command as a PR comment:
```
approve 8f3da0c5a0698c000c6c1be2f29f6c5ef683189f
```
